### PR TITLE
[#91] Add medicine domain — schema, backend service, and endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from backend.routers.auth_router import router as auth_router
 from backend.routers.food_router import router as food_router
 from backend.routers.group_router import router as group_router
 from backend.routers.meal_router import router as meal_router
+from backend.routers.medicine_router import router as medicine_router
 from backend.routers.pet_router import router as pet_router
 from backend.routers.user_router import router as user_router
 from backend.routers.weight_router import router as weight_router
@@ -75,6 +76,7 @@ app.include_router(pet_router)
 app.include_router(food_router)
 app.include_router(meal_router)
 app.include_router(weight_router)
+app.include_router(medicine_router)
 
 
 # Add Scalar API documentation

--- a/backend/models/medicine.py
+++ b/backend/models/medicine.py
@@ -1,0 +1,172 @@
+from datetime import datetime as dt
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+medication_table = "medications"
+treatment_course_table = "treatment_courses"
+medication_log_table = "medication_logs"
+
+
+# ================== Enums ==================
+
+
+class MedicationType(str, Enum):
+    ORAL = "oral"
+    TOPICAL = "topical"
+    INJECTION = "injection"
+    EYE_DROPS = "eye_drops"
+    EAR_DROPS = "ear_drops"
+    OTHER = "other"
+
+
+class DosageUnit(str, Enum):
+    TABLET = "tablet"
+    ML = "ml"
+    MG = "mg"
+    DROPS = "drops"
+    PUFF = "puff"
+    UNIT = "unit"
+    APPLICATION = "application"
+
+
+class TimeOfDay(str, Enum):
+    ALL_DAY = "all_day"
+    MORNING = "morning"
+    AFTERNOON = "afternoon"
+    EVENING = "evening"
+
+
+# ================== Request Models ==================
+
+
+class CreateMedicationRequest(BaseModel):
+    group_id: str = Field(..., description="Group that owns this medication")
+    name: str = Field(..., max_length=100, description="Medication name")
+    medication_type: MedicationType = Field(..., description="Type of medication")
+    default_dosage: Optional[float] = Field(None, gt=0, description="Default dosage amount")
+    dosage_unit: DosageUnit = Field(..., description="Unit of dosage measurement")
+    notes: Optional[str] = Field(None, max_length=500, description="Additional notes")
+
+
+class UpdateMedicationRequest(BaseModel):
+    name: Optional[str] = Field(None, max_length=100)
+    medication_type: Optional[MedicationType] = None
+    default_dosage: Optional[float] = Field(None, gt=0)
+    dosage_unit: Optional[DosageUnit] = None
+    notes: Optional[str] = Field(None, max_length=500)
+
+
+class CreateCourseRequest(BaseModel):
+    pet_id: str = Field(..., description="Pet receiving the treatment")
+    medication_id: str = Field(..., description="Medication being administered")
+    group_id: str = Field(..., description="Group context")
+    dosage: float = Field(..., gt=0, description="Dosage amount per administration")
+    dosage_unit: DosageUnit = Field(..., description="Dosage unit")
+    frequency_days: int = Field(1, ge=1, le=365, description="Every N days")
+    times_per_day: List[TimeOfDay] = Field(default=["morning"], description="Time slots per dosing day")
+    start_date: str = Field(..., description="Start date (YYYY-MM-DD)")
+    end_date: Optional[str] = Field(None, description="End date (YYYY-MM-DD), null = open-ended")
+    notes: Optional[str] = Field(None, max_length=500)
+
+
+class UpdateCourseRequest(BaseModel):
+    dosage: Optional[float] = Field(None, gt=0)
+    dosage_unit: Optional[DosageUnit] = None
+    frequency_days: Optional[int] = Field(None, ge=1, le=365)
+    times_per_day: Optional[List[TimeOfDay]] = None
+    end_date: Optional[str] = Field(None, description="End date (YYYY-MM-DD)")
+    notes: Optional[str] = Field(None, max_length=500)
+    local_date: Optional[str] = Field(None, description="Client local date (YYYY-MM-DD) for frequency reset")
+
+
+class CreateLogRequest(BaseModel):
+    pet_id: str = Field(..., description="Pet that received medication")
+    medication_id: str = Field(..., description="Medication administered")
+    group_id: str = Field(..., description="Group context")
+    course_id: Optional[str] = Field(None, description="Treatment course (null for ad-hoc)")
+    dosage: float = Field(..., gt=0, description="Actual dosage administered")
+    dosage_unit: DosageUnit = Field(..., description="Dosage unit")
+    time_of_day: Optional[TimeOfDay] = Field(None, description="Time slot")
+    notes: Optional[str] = Field(None, max_length=500)
+
+
+# ================== Response Models ==================
+
+
+class MedicationInfo(BaseModel):
+    id: str
+    group_id: str
+    name: str
+    medication_type: MedicationType
+    default_dosage: Optional[float] = None
+    dosage_unit: DosageUnit
+    notes: Optional[str] = None
+    creator_id: Optional[str] = None
+    is_active: bool
+    created_at: dt
+    updated_at: dt
+
+
+class TreatmentCourseInfo(BaseModel):
+    id: str
+    pet_id: str
+    pet_name: str
+    medication_id: str
+    medication_name: str
+    medication_type: MedicationType
+    group_id: str
+    dosage: float
+    dosage_unit: DosageUnit
+    frequency_days: int
+    times_per_day: List[str]
+    start_date: str
+    end_date: Optional[str] = None
+    notes: Optional[str] = None
+    created_by: Optional[str] = None
+    created_by_name: Optional[str] = None
+    is_active: bool
+    created_at: dt
+    updated_at: dt
+
+
+class MedicationLogInfo(BaseModel):
+    id: str
+    pet_id: str
+    medication_id: str
+    medication_name: str
+    group_id: str
+    course_id: Optional[str] = None
+    dosage: float
+    dosage_unit: DosageUnit
+    time_of_day: Optional[str] = None
+    administered_at: dt
+    administered_by: Optional[str] = None
+    administered_by_name: Optional[str] = None
+    notes: Optional[str] = None
+    is_active: bool
+    created_at: dt
+    updated_at: dt
+
+
+class ScheduledItem(BaseModel):
+    course_id: str
+    medication_id: str
+    medication_name: str
+    medication_type: MedicationType
+    dosage: float
+    dosage_unit: DosageUnit
+    time_of_day: str
+    is_done: bool
+    log_id: Optional[str] = None
+    administered_by_name: Optional[str] = None
+    administered_at: Optional[dt] = None
+
+
+class TodayScheduleResponse(BaseModel):
+    pet_id: str
+    date: str
+    scheduled_items: List[ScheduledItem]
+    ad_hoc_logs: List[MedicationLogInfo]
+    summary: dict

--- a/backend/routers/medicine_router.py
+++ b/backend/routers/medicine_router.py
@@ -1,0 +1,241 @@
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from backend.models.medicine import (
+    CreateCourseRequest,
+    CreateLogRequest,
+    CreateMedicationRequest,
+    UpdateCourseRequest,
+    UpdateMedicationRequest,
+)
+from backend.models.user import UserInfo
+from backend.services.auth_service import get_current_user
+from backend.services.medicine_service import MedicineService
+
+router = APIRouter(prefix="/medicine", tags=["medicine"])
+medicine_service = MedicineService()
+
+
+# ================== Today's Schedule (before path params) ==================
+
+
+@router.get("/today", response_model=dict)
+async def get_today_schedule(
+    current_user: Annotated[UserInfo, Depends(get_current_user)],
+    pet_id: str = Query(..., description="Pet ID to get today's schedule for"),
+    local_date: Optional[str] = Query(None, description="Client local date (YYYY-MM-DD)"),
+) -> dict:
+    """Get today's medication schedule with completion status."""
+    try:
+        schedule = await medicine_service.get_today_schedule(pet_id, current_user.id, local_date)
+        return {
+            "status": 1,
+            "data": schedule.model_dump(),
+            "message": f"Today's medication schedule for {schedule.date}",
+        }
+    except Exception as e:
+        raise e
+
+
+# ================== Medication CRUD ==================
+
+
+@router.post("/create", response_model=dict)
+async def create_medication(
+    request: CreateMedicationRequest,
+    current_user: Annotated[UserInfo, Depends(get_current_user)],
+) -> dict:
+    """Create a new medication entry in the group's medication database."""
+    try:
+        medication = await medicine_service.create_medication(request, current_user.id)
+        return {
+            "status": 1,
+            "data": medication.model_dump(),
+            "message": f"Medication '{medication.name}' created successfully",
+        }
+    except Exception as e:
+        raise e
+
+
+@router.get("/list", response_model=dict)
+async def list_medications(
+    current_user: Annotated[UserInfo, Depends(get_current_user)],
+    group_id: str = Query(..., description="Group ID to list medications for"),
+) -> dict:
+    """List all medications in a group."""
+    try:
+        medications = await medicine_service.list_medications(group_id, current_user.id)
+        return {
+            "status": 1,
+            "data": [m.model_dump() for m in medications],
+            "message": f"Found {len(medications)} medications",
+        }
+    except Exception as e:
+        raise e
+
+
+# ================== Treatment Course ==================
+
+
+@router.post("/course/create", response_model=dict)
+async def create_course(
+    request: CreateCourseRequest,
+    current_user: Annotated[UserInfo, Depends(get_current_user)],
+) -> dict:
+    """Create a new treatment course for a pet."""
+    try:
+        course = await medicine_service.create_course(request, current_user.id)
+        return {
+            "status": 1,
+            "data": course.model_dump(),
+            "message": f"Treatment course for '{course.medication_name}' created successfully",
+        }
+    except Exception as e:
+        raise e
+
+
+@router.post("/course/{course_id}/update", response_model=dict)
+async def update_course(
+    course_id: str,
+    request: UpdateCourseRequest,
+    current_user: Annotated[UserInfo, Depends(get_current_user)],
+) -> dict:
+    """Update an existing treatment course. If frequency_days changes, start_date resets to local_date."""
+    try:
+        course = await medicine_service.update_course(course_id, request, current_user.id)
+        return {
+            "status": 1,
+            "data": course.model_dump(),
+            "message": "Treatment course updated successfully",
+        }
+    except Exception as e:
+        raise e
+
+
+@router.post("/course/{course_id}/end", response_model=dict)
+async def end_course(
+    course_id: str,
+    current_user: Annotated[UserInfo, Depends(get_current_user)],
+    local_date: Optional[str] = Query(None, description="Client local date (YYYY-MM-DD) for end date"),
+) -> dict:
+    """End a treatment course by setting its end_date."""
+    try:
+        course = await medicine_service.end_course(course_id, current_user.id, local_date)
+        return {
+            "status": 1,
+            "data": course.model_dump(),
+            "message": "Treatment course ended successfully",
+        }
+    except Exception as e:
+        raise e
+
+
+@router.get("/course/list", response_model=dict)
+async def list_courses(
+    current_user: Annotated[UserInfo, Depends(get_current_user)],
+    pet_id: str = Query(..., description="Pet ID to list courses for"),
+    status: Optional[str] = Query("active", description="Filter: active, ended, or all"),
+) -> dict:
+    """List treatment courses for a pet."""
+    try:
+        courses = await medicine_service.list_courses(pet_id, current_user.id, course_status=status)
+        return {
+            "status": 1,
+            "data": [c.model_dump() for c in courses],
+            "message": f"Found {len(courses)} treatment courses",
+        }
+    except Exception as e:
+        raise e
+
+
+# ================== Medication Log ==================
+
+
+@router.post("/log/create", response_model=dict)
+async def create_log(
+    request: CreateLogRequest,
+    current_user: Annotated[UserInfo, Depends(get_current_user)],
+) -> dict:
+    """Record a medication administration."""
+    try:
+        log = await medicine_service.create_log(request, current_user.id)
+        return {
+            "status": 1,
+            "data": log.model_dump(),
+            "message": "Medication log recorded successfully",
+        }
+    except Exception as e:
+        raise e
+
+
+@router.post("/log/{log_id}/delete", response_model=dict)
+async def delete_log(
+    log_id: str,
+    current_user: Annotated[UserInfo, Depends(get_current_user)],
+) -> dict:
+    """Soft-delete a medication log (undo an administration record)."""
+    try:
+        result = await medicine_service.delete_log(log_id, current_user.id)
+        return {
+            "status": 1,
+            "data": result,
+            "message": "Medication log deleted successfully",
+        }
+    except Exception as e:
+        raise e
+
+
+# ================== Medication by ID (must be LAST — path param catches all) ==================
+
+
+@router.post("/{medication_id}/update", response_model=dict)
+async def update_medication(
+    medication_id: str,
+    request: UpdateMedicationRequest,
+    current_user: Annotated[UserInfo, Depends(get_current_user)],
+) -> dict:
+    """Update an existing medication entry."""
+    try:
+        medication = await medicine_service.update_medication(medication_id, request, current_user.id)
+        return {
+            "status": 1,
+            "data": medication.model_dump(),
+            "message": "Medication updated successfully",
+        }
+    except Exception as e:
+        raise e
+
+
+@router.post("/{medication_id}/delete", response_model=dict)
+async def delete_medication(
+    medication_id: str,
+    current_user: Annotated[UserInfo, Depends(get_current_user)],
+) -> dict:
+    """Soft-delete a medication entry."""
+    try:
+        result = await medicine_service.delete_medication(medication_id, current_user.id)
+        return {
+            "status": 1,
+            "data": result,
+            "message": "Medication deleted successfully",
+        }
+    except Exception as e:
+        raise e
+
+
+@router.get("/{medication_id}", response_model=dict)
+async def get_medication(
+    medication_id: str,
+    current_user: Annotated[UserInfo, Depends(get_current_user)],
+) -> dict:
+    """Get medication details."""
+    try:
+        medication = await medicine_service.get_medication(medication_id, current_user.id)
+        return {
+            "status": 1,
+            "data": medication.model_dump(),
+            "message": "Medication details retrieved successfully",
+        }
+    except Exception as e:
+        raise e

--- a/backend/services/medicine_service.py
+++ b/backend/services/medicine_service.py
@@ -1,0 +1,657 @@
+import uuid
+from datetime import date
+from datetime import datetime as dt
+from datetime import timezone as tz
+from typing import Dict, List, Optional
+
+from fastapi import HTTPException, status
+
+from backend.core.db_manager import get_db
+from backend.models.medicine import (
+    CreateCourseRequest,
+    CreateLogRequest,
+    CreateMedicationRequest,
+    MedicationInfo,
+    MedicationLogInfo,
+    ScheduledItem,
+    TodayScheduleResponse,
+    TreatmentCourseInfo,
+    UpdateCourseRequest,
+    UpdateMedicationRequest,
+    medication_log_table,
+    medication_table,
+    treatment_course_table,
+)
+
+
+class MedicineService:
+    """
+    MedicineService handles medication tracking business logic:
+    - Medication catalog (group-scoped)
+    - Treatment courses (open-ended recurring schedules)
+    - Medication logs (actual administration records)
+    - Today's schedule computation (is_dosing_day + log matching)
+    """
+
+    @property
+    def db(self):
+        return get_db()
+
+    # ================== ID Generation ==================
+
+    def _generate_medication_id(self) -> str:
+        return f"med_{uuid.uuid4().hex[:7]}"
+
+    def _generate_course_id(self) -> str:
+        return f"tc_{uuid.uuid4().hex[:8]}"
+
+    def _generate_log_id(self) -> str:
+        return f"mlog_{uuid.uuid4().hex[:6]}"
+
+    # ================== Permission Helpers ==================
+
+    async def _get_user_group_role(self, group_id: str, user_id: str) -> str:
+        sql = """
+        SELECT role FROM group_members
+        WHERE group_id = $1 AND user_id = $2 AND is_active = TRUE
+        """
+        result = await self.db.read_one(sql, group_id, user_id)
+        return result["role"] if result else "none"
+
+    async def _require_member(self, group_id: str, user_id: str) -> None:
+        role = await self._get_user_group_role(group_id, user_id)
+        if role not in ("creator", "member"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You need member or creator role to perform this action",
+            )
+
+    async def _require_viewer(self, group_id: str, user_id: str) -> None:
+        role = await self._get_user_group_role(group_id, user_id)
+        if role not in ("creator", "member", "viewer"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You don't have permission to view this resource",
+            )
+
+    async def _get_pet_group_id(self, pet_id: str) -> str:
+        sql = """
+        SELECT group_id FROM pets
+        WHERE id = $1 AND is_active = TRUE
+        """
+        result = await self.db.read_one(sql, pet_id)
+        if not result:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Pet not found",
+            )
+        return result["group_id"]
+
+    # ================== Medication CRUD ==================
+
+    async def create_medication(self, request: CreateMedicationRequest, user_id: str) -> MedicationInfo:
+        await self._require_member(request.group_id, user_id)
+
+        med_id = self._generate_medication_id()
+        sql = f"""
+        INSERT INTO {medication_table}
+            (id, group_id, name, medication_type, default_dosage, dosage_unit, notes, creator_id)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        RETURNING *
+        """
+        record = await self.db.execute_returning(
+            sql,
+            med_id,
+            request.group_id,
+            request.name,
+            request.medication_type.value,
+            request.default_dosage,
+            request.dosage_unit.value,
+            request.notes,
+            user_id,
+        )
+        return MedicationInfo(**record)
+
+    async def get_medication(self, medication_id: str, user_id: str) -> MedicationInfo:
+        sql = f"""
+        SELECT * FROM {medication_table}
+        WHERE id = $1 AND is_active = TRUE
+        """
+        record = await self.db.read_one(sql, medication_id)
+        if not record:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Medication not found",
+            )
+        await self._require_viewer(record["group_id"], user_id)
+        return MedicationInfo(**record)
+
+    async def list_medications(self, group_id: str, user_id: str) -> List[MedicationInfo]:
+        await self._require_viewer(group_id, user_id)
+        sql = f"""
+        SELECT * FROM {medication_table}
+        WHERE group_id = $1 AND is_active = TRUE
+        ORDER BY name ASC
+        """
+        records = await self.db.read(sql, group_id)
+        return [MedicationInfo(**r) for r in records]
+
+    async def update_medication(
+        self, medication_id: str, request: UpdateMedicationRequest, user_id: str
+    ) -> MedicationInfo:
+        # Get existing
+        sql = f"SELECT * FROM {medication_table} WHERE id = $1 AND is_active = TRUE"
+        existing = await self.db.read_one(sql, medication_id)
+        if not existing:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Medication not found",
+            )
+        await self._require_member(existing["group_id"], user_id)
+
+        update_fields = []
+        params = []
+        param_count = 0
+
+        if request.name is not None:
+            param_count += 1
+            update_fields.append(f"name = ${param_count}")
+            params.append(request.name)
+
+        if request.medication_type is not None:
+            param_count += 1
+            update_fields.append(f"medication_type = ${param_count}")
+            params.append(request.medication_type.value)
+
+        if request.default_dosage is not None:
+            param_count += 1
+            update_fields.append(f"default_dosage = ${param_count}")
+            params.append(request.default_dosage)
+
+        if request.dosage_unit is not None:
+            param_count += 1
+            update_fields.append(f"dosage_unit = ${param_count}")
+            params.append(request.dosage_unit.value)
+
+        if request.notes is not None:
+            param_count += 1
+            update_fields.append(f"notes = ${param_count}")
+            params.append(request.notes)
+
+        if not update_fields:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No fields to update",
+            )
+
+        param_count += 1
+        update_sql = f"""
+        UPDATE {medication_table}
+        SET {', '.join(update_fields)}
+        WHERE id = ${param_count}
+        RETURNING *
+        """
+        params.append(medication_id)
+        record = await self.db.execute_returning(update_sql, *params)
+        return MedicationInfo(**record)
+
+    async def delete_medication(self, medication_id: str, user_id: str) -> Dict[str, str]:
+        sql = f"SELECT * FROM {medication_table} WHERE id = $1 AND is_active = TRUE"
+        existing = await self.db.read_one(sql, medication_id)
+        if not existing:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Medication not found",
+            )
+        await self._require_member(existing["group_id"], user_id)
+
+        await self.db.execute(
+            f"UPDATE {medication_table} SET is_active = FALSE WHERE id = $1",
+            medication_id,
+        )
+        return {"id": medication_id, "deleted": True}
+
+    # ================== Treatment Course CRUD ==================
+
+    def _parse_date(self, date_str: str, field_name: str) -> date:
+        try:
+            return dt.strptime(date_str, "%Y-%m-%d").date()
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{field_name} must be in YYYY-MM-DD format",
+            )
+
+    async def create_course(self, request: CreateCourseRequest, user_id: str) -> TreatmentCourseInfo:
+        await self._require_member(request.group_id, user_id)
+
+        # Validate pet exists and belongs to group
+        pet_group_id = await self._get_pet_group_id(request.pet_id)
+        if pet_group_id != request.group_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Pet does not belong to the specified group",
+            )
+
+        # Validate medication exists and belongs to group
+        med_sql = f"SELECT * FROM {medication_table} WHERE id = $1 AND is_active = TRUE"
+        med = await self.db.read_one(med_sql, request.medication_id)
+        if not med:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Medication not found",
+            )
+        if med["group_id"] != request.group_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Medication does not belong to the specified group",
+            )
+
+        start_date = self._parse_date(request.start_date, "start_date")
+        end_date = self._parse_date(request.end_date, "end_date") if request.end_date else None
+
+        times_per_day_values = [t.value if hasattr(t, "value") else t for t in request.times_per_day]
+
+        course_id = self._generate_course_id()
+        sql = f"""
+        INSERT INTO {treatment_course_table}
+            (id, pet_id, medication_id, group_id, dosage, dosage_unit,
+             frequency_days, times_per_day, start_date, end_date, notes, created_by)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8::time_of_day_enum[], $9, $10, $11, $12)
+        RETURNING *
+        """
+        record = await self.db.execute_returning(
+            sql,
+            course_id,
+            request.pet_id,
+            request.medication_id,
+            request.group_id,
+            request.dosage,
+            request.dosage_unit.value,
+            request.frequency_days,
+            times_per_day_values,
+            start_date,
+            end_date,
+            request.notes,
+            user_id,
+        )
+        return await self._enrich_course(record)
+
+    async def _enrich_course(self, record: dict) -> TreatmentCourseInfo:
+        """Enrich a raw course record with pet name, medication name, creator name."""
+        pet_sql = "SELECT name FROM pets WHERE id = $1"
+        pet = await self.db.read_one(pet_sql, record["pet_id"])
+
+        med_sql = f"SELECT name, medication_type FROM {medication_table} WHERE id = $1"
+        med = await self.db.read_one(med_sql, record["medication_id"])
+
+        creator_name = None
+        if record.get("created_by"):
+            user_sql = "SELECT name FROM users WHERE id = $1"
+            user = await self.db.read_one(user_sql, record["created_by"])
+            creator_name = user["name"] if user else None
+
+        # Convert times_per_day to list of strings
+        times = record["times_per_day"]
+        if isinstance(times, (list, tuple)):
+            times_list = [str(t) for t in times]
+        else:
+            times_list = [str(times)]
+
+        return TreatmentCourseInfo(
+            id=record["id"],
+            pet_id=record["pet_id"],
+            pet_name=pet["name"] if pet else "Unknown",
+            medication_id=record["medication_id"],
+            medication_name=med["name"] if med else "Unknown",
+            medication_type=med["medication_type"] if med else "other",
+            group_id=record["group_id"],
+            dosage=float(record["dosage"]),
+            dosage_unit=record["dosage_unit"],
+            frequency_days=record["frequency_days"],
+            times_per_day=times_list,
+            start_date=str(record["start_date"]),
+            end_date=str(record["end_date"]) if record["end_date"] else None,
+            notes=record.get("notes"),
+            created_by=record.get("created_by"),
+            created_by_name=creator_name,
+            is_active=record["is_active"],
+            created_at=record["created_at"],
+            updated_at=record["updated_at"],
+        )
+
+    async def list_courses(
+        self,
+        pet_id: str,
+        user_id: str,
+        course_status: str = "active",
+    ) -> List[TreatmentCourseInfo]:
+        group_id = await self._get_pet_group_id(pet_id)
+        await self._require_viewer(group_id, user_id)
+
+        conditions = [
+            "tc.pet_id = $1",
+            "tc.is_active = TRUE",
+        ]
+
+        if course_status == "active":
+            conditions.append("(tc.end_date IS NULL OR tc.end_date >= CURRENT_DATE)")
+        elif course_status == "ended":
+            conditions.append("tc.end_date IS NOT NULL AND tc.end_date < CURRENT_DATE")
+        # "all" — no extra condition
+
+        sql = f"""
+        SELECT tc.* FROM {treatment_course_table} tc
+        WHERE {' AND '.join(conditions)}
+        ORDER BY tc.created_at DESC
+        """
+        records = await self.db.read(sql, pet_id)
+        return [await self._enrich_course(r) for r in records]
+
+    async def update_course(
+        self,
+        course_id: str,
+        request: UpdateCourseRequest,
+        user_id: str,
+    ) -> TreatmentCourseInfo:
+        sql = f"SELECT * FROM {treatment_course_table} WHERE id = $1 AND is_active = TRUE"
+        existing = await self.db.read_one(sql, course_id)
+        if not existing:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Treatment course not found",
+            )
+        await self._require_member(existing["group_id"], user_id)
+
+        update_fields = []
+        params = []
+        param_count = 0
+
+        if request.dosage is not None:
+            param_count += 1
+            update_fields.append(f"dosage = ${param_count}")
+            params.append(request.dosage)
+
+        if request.dosage_unit is not None:
+            param_count += 1
+            update_fields.append(f"dosage_unit = ${param_count}")
+            params.append(request.dosage_unit.value)
+
+        frequency_changed = False
+        if request.frequency_days is not None:
+            param_count += 1
+            update_fields.append(f"frequency_days = ${param_count}")
+            params.append(request.frequency_days)
+            frequency_changed = True
+
+        if request.times_per_day is not None:
+            times_values = [t.value if hasattr(t, "value") else t for t in request.times_per_day]
+            param_count += 1
+            update_fields.append(f"times_per_day = ${param_count}::time_of_day_enum[]")
+            params.append(times_values)
+
+        if request.end_date is not None:
+            end_date = self._parse_date(request.end_date, "end_date")
+            param_count += 1
+            update_fields.append(f"end_date = ${param_count}")
+            params.append(end_date)
+
+        if request.notes is not None:
+            param_count += 1
+            update_fields.append(f"notes = ${param_count}")
+            params.append(request.notes)
+
+        # If frequency changed, reset start_date to local_date (today from client)
+        if frequency_changed:
+            local_date_str = request.local_date
+            if not local_date_str:
+                local_date_str = dt.now(tz.utc).strftime("%Y-%m-%d")
+            new_start = self._parse_date(local_date_str, "local_date")
+            param_count += 1
+            update_fields.append(f"start_date = ${param_count}")
+            params.append(new_start)
+
+        if not update_fields:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No fields to update",
+            )
+
+        param_count += 1
+        update_sql = f"""
+        UPDATE {treatment_course_table}
+        SET {', '.join(update_fields)}
+        WHERE id = ${param_count}
+        RETURNING *
+        """
+        params.append(course_id)
+        record = await self.db.execute_returning(update_sql, *params)
+        return await self._enrich_course(record)
+
+    async def end_course(self, course_id: str, user_id: str, local_date: Optional[str] = None) -> TreatmentCourseInfo:
+        sql = f"SELECT * FROM {treatment_course_table} WHERE id = $1 AND is_active = TRUE"
+        existing = await self.db.read_one(sql, course_id)
+        if not existing:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Treatment course not found",
+            )
+        await self._require_member(existing["group_id"], user_id)
+
+        if not local_date:
+            local_date = dt.now(tz.utc).strftime("%Y-%m-%d")
+        end_date = self._parse_date(local_date, "local_date")
+
+        update_sql = f"""
+        UPDATE {treatment_course_table}
+        SET end_date = $1
+        WHERE id = $2
+        RETURNING *
+        """
+        record = await self.db.execute_returning(update_sql, end_date, course_id)
+        return await self._enrich_course(record)
+
+    # ================== Medication Log CRUD ==================
+
+    async def create_log(self, request: CreateLogRequest, user_id: str) -> MedicationLogInfo:
+        await self._require_member(request.group_id, user_id)
+
+        # Validate medication exists
+        med_sql = f"SELECT * FROM {medication_table} WHERE id = $1 AND is_active = TRUE"
+        med = await self.db.read_one(med_sql, request.medication_id)
+        if not med:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Medication not found",
+            )
+
+        # If course_id provided, validate it exists
+        if request.course_id:
+            course_sql = f"SELECT * FROM {treatment_course_table} " f"WHERE id = $1 AND is_active = TRUE"
+            course = await self.db.read_one(course_sql, request.course_id)
+            if not course:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Treatment course not found",
+                )
+
+        log_id = self._generate_log_id()
+        time_of_day_val = request.time_of_day.value if request.time_of_day else None
+
+        sql = f"""
+        INSERT INTO {medication_log_table}
+            (id, pet_id, medication_id, group_id, course_id,
+             dosage, dosage_unit, time_of_day, administered_by, notes)
+        VALUES ($1, $2, $3, $4, $5, $6, $7,
+                $8::time_of_day_enum, $9, $10)
+        RETURNING *
+        """
+        record = await self.db.execute_returning(
+            sql,
+            log_id,
+            request.pet_id,
+            request.medication_id,
+            request.group_id,
+            request.course_id,
+            request.dosage,
+            request.dosage_unit.value,
+            time_of_day_val,
+            user_id,
+            request.notes,
+        )
+        return await self._enrich_log(record)
+
+    async def _enrich_log(self, record: dict) -> MedicationLogInfo:
+        med_sql = f"SELECT name FROM {medication_table} WHERE id = $1"
+        med = await self.db.read_one(med_sql, record["medication_id"])
+
+        admin_name = None
+        if record.get("administered_by"):
+            user_sql = "SELECT name FROM users WHERE id = $1"
+            user = await self.db.read_one(user_sql, record["administered_by"])
+            admin_name = user["name"] if user else None
+
+        return MedicationLogInfo(
+            id=record["id"],
+            pet_id=record["pet_id"],
+            medication_id=record["medication_id"],
+            medication_name=med["name"] if med else "Unknown",
+            group_id=record["group_id"],
+            course_id=record.get("course_id"),
+            dosage=float(record["dosage"]),
+            dosage_unit=record["dosage_unit"],
+            time_of_day=record.get("time_of_day"),
+            administered_at=record["administered_at"],
+            administered_by=record.get("administered_by"),
+            administered_by_name=admin_name,
+            notes=record.get("notes"),
+            is_active=record["is_active"],
+            created_at=record["created_at"],
+            updated_at=record["updated_at"],
+        )
+
+    async def delete_log(self, log_id: str, user_id: str) -> Dict[str, str]:
+        sql = f"SELECT * FROM {medication_log_table} WHERE id = $1 AND is_active = TRUE"
+        existing = await self.db.read_one(sql, log_id)
+        if not existing:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Medication log not found",
+            )
+        await self._require_member(existing["group_id"], user_id)
+
+        await self.db.execute(
+            f"UPDATE {medication_log_table} SET is_active = FALSE WHERE id = $1",
+            log_id,
+        )
+        return {"id": log_id, "deleted": True}
+
+    # ================== Today's Schedule ==================
+
+    def _is_dosing_day(self, start_date: date, frequency_days: int, check_date: date, end_date: Optional[date]) -> bool:
+        if check_date < start_date:
+            return False
+        if end_date and check_date > end_date:
+            return False
+        days_since_start = (check_date - start_date).days
+        return days_since_start % frequency_days == 0
+
+    async def get_today_schedule(
+        self, pet_id: str, user_id: str, local_date: Optional[str] = None
+    ) -> TodayScheduleResponse:
+        group_id = await self._get_pet_group_id(pet_id)
+        await self._require_viewer(group_id, user_id)
+
+        if local_date:
+            check_date = self._parse_date(local_date, "local_date")
+        else:
+            check_date = dt.now(tz.utc).date()
+
+        date_str = check_date.isoformat()
+
+        # Get all active courses for this pet
+        course_sql = f"""
+        SELECT tc.*, m.name as medication_name, m.medication_type
+        FROM {treatment_course_table} tc
+        JOIN {medication_table} m ON tc.medication_id = m.id
+        WHERE tc.pet_id = $1
+          AND tc.is_active = TRUE
+          AND m.is_active = TRUE
+          AND tc.start_date <= $2
+          AND (tc.end_date IS NULL OR tc.end_date >= $2)
+        """
+        courses = await self.db.read(course_sql, pet_id, check_date)
+
+        # Get all logs for this pet on this date
+        log_sql = f"""
+        SELECT ml.*, u.name as administered_by_name
+        FROM {medication_log_table} ml
+        LEFT JOIN users u ON ml.administered_by = u.id
+        WHERE ml.pet_id = $1
+          AND ml.is_active = TRUE
+          AND DATE(ml.administered_at) = $2
+        """
+        logs = await self.db.read(log_sql, pet_id, check_date)
+
+        # Build scheduled items
+        scheduled_items: List[ScheduledItem] = []
+        for course in courses:
+            course_start = course["start_date"]
+            course_end = course["end_date"]
+            freq = course["frequency_days"]
+
+            if not self._is_dosing_day(course_start, freq, check_date, course_end):
+                continue
+
+            times = course["times_per_day"]
+            if isinstance(times, (list, tuple)):
+                times_list = [str(t) for t in times]
+            else:
+                times_list = [str(times)]
+
+            for time_slot in times_list:
+                # Find matching log
+                matching_log = None
+                for log in logs:
+                    if log.get("course_id") == course["id"] and (
+                        time_slot == "all_day" or str(log.get("time_of_day", "")) == time_slot
+                    ):
+                        matching_log = log
+                        break
+
+                scheduled_items.append(
+                    ScheduledItem(
+                        course_id=course["id"],
+                        medication_id=course["medication_id"],
+                        medication_name=course["medication_name"],
+                        medication_type=course["medication_type"],
+                        dosage=float(course["dosage"]),
+                        dosage_unit=course["dosage_unit"],
+                        time_of_day=time_slot,
+                        is_done=matching_log is not None,
+                        log_id=matching_log["id"] if matching_log else None,
+                        administered_by_name=(matching_log.get("administered_by_name") if matching_log else None),
+                        administered_at=(matching_log["administered_at"] if matching_log else None),
+                    )
+                )
+
+        # Ad-hoc logs: logs without a course_id on this date
+        ad_hoc_logs = []
+        for log in logs:
+            if not log.get("course_id"):
+                ad_hoc_logs.append(await self._enrich_log(log))
+
+        total = len(scheduled_items)
+        completed = sum(1 for item in scheduled_items if item.is_done)
+
+        return TodayScheduleResponse(
+            pet_id=pet_id,
+            date=date_str,
+            scheduled_items=scheduled_items,
+            ad_hoc_logs=ad_hoc_logs,
+            summary={
+                "total_scheduled": total,
+                "completed": completed,
+                "pending": total - completed,
+            },
+        )

--- a/backend/tests/unit/test_medicine_service.py
+++ b/backend/tests/unit/test_medicine_service.py
@@ -1,0 +1,641 @@
+"""
+Unit tests for ``backend.services.medicine_service.MedicineService``.
+
+These tests follow the unit-tier rules:
+
+* No FastAPI app import — only ``MedicineService`` is imported.
+* No real Postgres — ``get_db`` is patched to return an ``AsyncMock``.
+* Each test gets its own fresh mocks via fixtures (parallel-safe).
+
+Authorization coverage focuses on the ``creator`` / ``member`` (edit)
+vs ``viewer`` (view-only) gate that governs every operation.
+"""
+
+from datetime import date
+from datetime import datetime as dt
+from datetime import timezone as tz
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from backend.models.medicine import (
+    CreateCourseRequest,
+    CreateLogRequest,
+    CreateMedicationRequest,
+    DosageUnit,
+    MedicationType,
+    TimeOfDay,
+    UpdateMedicationRequest,
+)
+
+# ================================================================
+# Helpers
+# ================================================================
+
+
+def _make_medication_row(**overrides):
+    base = {
+        "id": "med_abc1234",
+        "group_id": "grp_test",
+        "name": "Amlodipine",
+        "medication_type": "oral",
+        "default_dosage": 1.0,
+        "dosage_unit": "tablet",
+        "notes": None,
+        "creator_id": "u_test01",
+        "is_active": True,
+        "created_at": dt(2026, 4, 9, 12, tzinfo=tz.utc),
+        "updated_at": dt(2026, 4, 9, 12, tzinfo=tz.utc),
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_course_row(**overrides):
+    base = {
+        "id": "tc_abc12345",
+        "pet_id": "p_test01",
+        "medication_id": "med_abc1234",
+        "group_id": "grp_test",
+        "dosage": 1.0,
+        "dosage_unit": "tablet",
+        "frequency_days": 1,
+        "times_per_day": ["morning", "evening"],
+        "start_date": date(2026, 4, 9),
+        "end_date": None,
+        "notes": None,
+        "created_by": "u_test01",
+        "is_active": True,
+        "created_at": dt(2026, 4, 9, 12, tzinfo=tz.utc),
+        "updated_at": dt(2026, 4, 9, 12, tzinfo=tz.utc),
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_log_row(**overrides):
+    base = {
+        "id": "mlog_abc123",
+        "pet_id": "p_test01",
+        "medication_id": "med_abc1234",
+        "group_id": "grp_test",
+        "course_id": "tc_abc12345",
+        "dosage": 1.0,
+        "dosage_unit": "tablet",
+        "time_of_day": "morning",
+        "administered_at": dt(2026, 4, 9, 8, 0, tzinfo=tz.utc),
+        "administered_by": "u_test01",
+        "notes": None,
+        "is_active": True,
+        "created_at": dt(2026, 4, 9, 8, 0, tzinfo=tz.utc),
+        "updated_at": dt(2026, 4, 9, 8, 0, tzinfo=tz.utc),
+    }
+    base.update(overrides)
+    return base
+
+
+def _role_row(role):
+    return {"role": role}
+
+
+# ================================================================
+# Fixtures
+# ================================================================
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.read = AsyncMock()
+    db.read_one = AsyncMock()
+    db.insert = AsyncMock()
+    db.insert_one = AsyncMock()
+    db.execute = AsyncMock()
+    db.execute_returning = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def medicine_service(monkeypatch, mock_db):
+    monkeypatch.setattr("backend.services.medicine_service.get_db", lambda: mock_db)
+    from backend.services.medicine_service import MedicineService
+
+    return MedicineService()
+
+
+# ================================================================
+# create_medication
+# ================================================================
+
+
+class TestCreateMedication:
+    @pytest.mark.asyncio
+    async def test_member_can_create(self, medicine_service, mock_db):
+        mock_db.read_one.return_value = _role_row("member")
+        mock_db.execute_returning.return_value = _make_medication_row()
+
+        req = CreateMedicationRequest(
+            group_id="grp_test",
+            name="Amlodipine",
+            medication_type=MedicationType.ORAL,
+            dosage_unit=DosageUnit.TABLET,
+        )
+        result = await medicine_service.create_medication(req, "u_test01")
+        assert result.name == "Amlodipine"
+        assert result.medication_type == MedicationType.ORAL
+
+    @pytest.mark.asyncio
+    async def test_viewer_cannot_create(self, medicine_service, mock_db):
+        mock_db.read_one.return_value = _role_row("viewer")
+
+        req = CreateMedicationRequest(
+            group_id="grp_test",
+            name="Amlodipine",
+            medication_type=MedicationType.ORAL,
+            dosage_unit=DosageUnit.TABLET,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await medicine_service.create_medication(req, "u_viewer")
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_stranger_cannot_create(self, medicine_service, mock_db):
+        mock_db.read_one.return_value = None  # not a group member
+
+        req = CreateMedicationRequest(
+            group_id="grp_test",
+            name="Amlodipine",
+            medication_type=MedicationType.ORAL,
+            dosage_unit=DosageUnit.TABLET,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await medicine_service.create_medication(req, "u_stranger")
+        assert exc_info.value.status_code == 403
+
+
+# ================================================================
+# list_medications
+# ================================================================
+
+
+class TestListMedications:
+    @pytest.mark.asyncio
+    async def test_viewer_can_list(self, medicine_service, mock_db):
+        mock_db.read_one.return_value = _role_row("viewer")
+        mock_db.read.return_value = [_make_medication_row(), _make_medication_row(id="med_xyz9876")]
+
+        result = await medicine_service.list_medications("grp_test", "u_viewer")
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_stranger_cannot_list(self, medicine_service, mock_db):
+        mock_db.read_one.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await medicine_service.list_medications("grp_test", "u_stranger")
+        assert exc_info.value.status_code == 403
+
+
+# ================================================================
+# update_medication
+# ================================================================
+
+
+class TestUpdateMedication:
+    @pytest.mark.asyncio
+    async def test_member_can_update(self, medicine_service, mock_db):
+        mock_db.read_one.side_effect = [
+            _make_medication_row(),  # existing med
+            _role_row("member"),  # role check
+        ]
+        mock_db.execute_returning.return_value = _make_medication_row(name="Updated Name")
+
+        req = UpdateMedicationRequest(name="Updated Name")
+        result = await medicine_service.update_medication("med_abc1234", req, "u_test01")
+        assert result.name == "Updated Name"
+
+    @pytest.mark.asyncio
+    async def test_viewer_cannot_update(self, medicine_service, mock_db):
+        mock_db.read_one.side_effect = [
+            _make_medication_row(),  # existing med
+            _role_row("viewer"),  # role check
+        ]
+
+        req = UpdateMedicationRequest(name="Updated Name")
+        with pytest.raises(HTTPException) as exc_info:
+            await medicine_service.update_medication("med_abc1234", req, "u_viewer")
+        assert exc_info.value.status_code == 403
+
+
+# ================================================================
+# delete_medication
+# ================================================================
+
+
+class TestDeleteMedication:
+    @pytest.mark.asyncio
+    async def test_member_can_delete(self, medicine_service, mock_db):
+        mock_db.read_one.side_effect = [
+            _make_medication_row(),  # existing med
+            _role_row("member"),  # role check
+        ]
+
+        result = await medicine_service.delete_medication("med_abc1234", "u_test01")
+        assert result["deleted"] is True
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises_404(self, medicine_service, mock_db):
+        mock_db.read_one.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await medicine_service.delete_medication("med_missing", "u_test01")
+        assert exc_info.value.status_code == 404
+
+
+# ================================================================
+# create_course
+# ================================================================
+
+
+class TestCreateCourse:
+    @pytest.mark.asyncio
+    async def test_member_can_create_course(self, medicine_service, mock_db):
+        mock_db.read_one.side_effect = [
+            _role_row("member"),  # _require_member
+            {"group_id": "grp_test"},  # _get_pet_group_id
+            _make_medication_row(),  # medication exists
+        ]
+        mock_db.execute_returning.return_value = _make_course_row()
+        # _enrich_course lookups
+        mock_db.read_one.side_effect = [
+            _role_row("member"),
+            {"group_id": "grp_test"},
+            _make_medication_row(),
+            {"name": "Fluffy"},  # pet name
+            {"name": "Amlodipine", "medication_type": "oral"},  # medication
+            {"name": "Test User"},  # creator name
+        ]
+
+        req = CreateCourseRequest(
+            pet_id="p_test01",
+            medication_id="med_abc1234",
+            group_id="grp_test",
+            dosage=1.0,
+            dosage_unit=DosageUnit.TABLET,
+            frequency_days=1,
+            times_per_day=[TimeOfDay.MORNING, TimeOfDay.EVENING],
+            start_date="2026-04-09",
+        )
+        result = await medicine_service.create_course(req, "u_test01")
+        assert result.medication_name == "Amlodipine"
+        assert result.frequency_days == 1
+
+    @pytest.mark.asyncio
+    async def test_viewer_cannot_create_course(self, medicine_service, mock_db):
+        mock_db.read_one.return_value = _role_row("viewer")
+
+        req = CreateCourseRequest(
+            pet_id="p_test01",
+            medication_id="med_abc1234",
+            group_id="grp_test",
+            dosage=1.0,
+            dosage_unit=DosageUnit.TABLET,
+            start_date="2026-04-09",
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await medicine_service.create_course(req, "u_viewer")
+        assert exc_info.value.status_code == 403
+
+
+# ================================================================
+# end_course
+# ================================================================
+
+
+class TestEndCourse:
+    @pytest.mark.asyncio
+    async def test_member_can_end_course(self, medicine_service, mock_db):
+        mock_db.read_one.side_effect = [
+            _make_course_row(),  # existing course
+            _role_row("member"),  # role check
+        ]
+        ended_row = _make_course_row(end_date=date(2026, 4, 10))
+        mock_db.execute_returning.return_value = ended_row
+        # _enrich_course lookups
+        mock_db.read_one.side_effect = [
+            _make_course_row(),
+            _role_row("member"),
+            {"name": "Fluffy"},
+            {"name": "Amlodipine", "medication_type": "oral"},
+            {"name": "Test User"},
+        ]
+
+        result = await medicine_service.end_course("tc_abc12345", "u_test01", "2026-04-10")
+        assert result.end_date == "2026-04-10"
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises_404(self, medicine_service, mock_db):
+        mock_db.read_one.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await medicine_service.end_course("tc_missing", "u_test01")
+        assert exc_info.value.status_code == 404
+
+
+# ================================================================
+# create_log
+# ================================================================
+
+
+class TestCreateLog:
+    @pytest.mark.asyncio
+    async def test_member_can_create_log(self, medicine_service, mock_db):
+        mock_db.read_one.side_effect = [
+            _role_row("member"),  # _require_member
+            _make_medication_row(),  # medication exists
+            _make_course_row(),  # course exists
+        ]
+        mock_db.execute_returning.return_value = _make_log_row()
+        # _enrich_log lookups
+        mock_db.read_one.side_effect = [
+            _role_row("member"),
+            _make_medication_row(),
+            _make_course_row(),
+            {"name": "Amlodipine"},  # med name
+            {"name": "Test User"},  # admin name
+        ]
+
+        req = CreateLogRequest(
+            pet_id="p_test01",
+            medication_id="med_abc1234",
+            group_id="grp_test",
+            course_id="tc_abc12345",
+            dosage=1.0,
+            dosage_unit=DosageUnit.TABLET,
+            time_of_day=TimeOfDay.MORNING,
+        )
+        result = await medicine_service.create_log(req, "u_test01")
+        assert result.medication_name == "Amlodipine"
+
+    @pytest.mark.asyncio
+    async def test_viewer_cannot_create_log(self, medicine_service, mock_db):
+        mock_db.read_one.return_value = _role_row("viewer")
+
+        req = CreateLogRequest(
+            pet_id="p_test01",
+            medication_id="med_abc1234",
+            group_id="grp_test",
+            dosage=1.0,
+            dosage_unit=DosageUnit.TABLET,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await medicine_service.create_log(req, "u_viewer")
+        assert exc_info.value.status_code == 403
+
+
+# ================================================================
+# delete_log
+# ================================================================
+
+
+class TestDeleteLog:
+    @pytest.mark.asyncio
+    async def test_member_can_delete_log(self, medicine_service, mock_db):
+        mock_db.read_one.side_effect = [
+            _make_log_row(),  # existing log
+            _role_row("member"),  # role check
+        ]
+
+        result = await medicine_service.delete_log("mlog_abc123", "u_test01")
+        assert result["deleted"] is True
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises_404(self, medicine_service, mock_db):
+        mock_db.read_one.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await medicine_service.delete_log("mlog_missing", "u_test01")
+        assert exc_info.value.status_code == 404
+
+
+# ================================================================
+# _is_dosing_day
+# ================================================================
+
+
+class TestIsDosingDay:
+    def test_daily_is_always_dosing_day(self, medicine_service):
+        assert medicine_service._is_dosing_day(date(2026, 4, 1), 1, date(2026, 4, 5), None)
+
+    def test_every_2_days_alternates(self, medicine_service):
+        start = date(2026, 4, 1)
+        # Day 0 (start): dosing
+        assert medicine_service._is_dosing_day(start, 2, date(2026, 4, 1), None)
+        # Day 1: no dosing
+        assert not medicine_service._is_dosing_day(start, 2, date(2026, 4, 2), None)
+        # Day 2: dosing
+        assert medicine_service._is_dosing_day(start, 2, date(2026, 4, 3), None)
+
+    def test_before_start_date_is_not_dosing(self, medicine_service):
+        assert not medicine_service._is_dosing_day(date(2026, 4, 5), 1, date(2026, 4, 3), None)
+
+    def test_after_end_date_is_not_dosing(self, medicine_service):
+        assert not medicine_service._is_dosing_day(date(2026, 4, 1), 1, date(2026, 4, 10), date(2026, 4, 5))
+
+    def test_on_end_date_is_dosing(self, medicine_service):
+        assert medicine_service._is_dosing_day(date(2026, 4, 1), 1, date(2026, 4, 5), date(2026, 4, 5))
+
+    def test_weekly_frequency(self, medicine_service):
+        start = date(2026, 4, 1)  # Tuesday
+        # Day 0: dosing
+        assert medicine_service._is_dosing_day(start, 7, date(2026, 4, 1), None)
+        # Day 3: no dosing
+        assert not medicine_service._is_dosing_day(start, 7, date(2026, 4, 4), None)
+        # Day 7: dosing
+        assert medicine_service._is_dosing_day(start, 7, date(2026, 4, 8), None)
+
+
+# ================================================================
+# get_today_schedule
+# ================================================================
+
+
+class TestGetTodaySchedule:
+    @pytest.mark.asyncio
+    async def test_returns_scheduled_items(self, medicine_service, mock_db):
+        # _get_pet_group_id
+        mock_db.read_one.side_effect = [
+            {"group_id": "grp_test"},  # pet group
+            _role_row("viewer"),  # viewer permission
+        ]
+        # courses
+        mock_db.read.side_effect = [
+            [  # courses query
+                {
+                    "id": "tc_001",
+                    "pet_id": "p_test01",
+                    "medication_id": "med_001",
+                    "medication_name": "Amlodipine",
+                    "medication_type": "oral",
+                    "group_id": "grp_test",
+                    "dosage": 1.0,
+                    "dosage_unit": "tablet",
+                    "frequency_days": 1,
+                    "times_per_day": ["morning", "evening"],
+                    "start_date": date(2026, 4, 1),
+                    "end_date": None,
+                },
+            ],
+            [],  # logs query (empty = nothing done yet)
+        ]
+
+        result = await medicine_service.get_today_schedule("p_test01", "u_viewer", "2026-04-09")
+        assert result.date == "2026-04-09"
+        assert len(result.scheduled_items) == 2
+        assert result.scheduled_items[0].time_of_day == "morning"
+        assert result.scheduled_items[0].is_done is False
+        assert result.scheduled_items[1].time_of_day == "evening"
+        assert result.summary["total_scheduled"] == 2
+        assert result.summary["pending"] == 2
+
+    @pytest.mark.asyncio
+    async def test_marks_done_when_log_exists(self, medicine_service, mock_db):
+        mock_db.read_one.side_effect = [
+            {"group_id": "grp_test"},
+            _role_row("member"),
+        ]
+        mock_db.read.side_effect = [
+            [  # courses
+                {
+                    "id": "tc_001",
+                    "pet_id": "p_test01",
+                    "medication_id": "med_001",
+                    "medication_name": "Amlodipine",
+                    "medication_type": "oral",
+                    "group_id": "grp_test",
+                    "dosage": 1.0,
+                    "dosage_unit": "tablet",
+                    "frequency_days": 1,
+                    "times_per_day": ["morning"],
+                    "start_date": date(2026, 4, 1),
+                    "end_date": None,
+                },
+            ],
+            [  # logs — morning is done
+                {
+                    "id": "mlog_001",
+                    "pet_id": "p_test01",
+                    "medication_id": "med_001",
+                    "group_id": "grp_test",
+                    "course_id": "tc_001",
+                    "dosage": 1.0,
+                    "dosage_unit": "tablet",
+                    "time_of_day": "morning",
+                    "administered_at": dt(2026, 4, 9, 8, 0, tzinfo=tz.utc),
+                    "administered_by": "u_test01",
+                    "administered_by_name": "David",
+                    "notes": None,
+                    "is_active": True,
+                    "created_at": dt(2026, 4, 9, 8, 0, tzinfo=tz.utc),
+                    "updated_at": dt(2026, 4, 9, 8, 0, tzinfo=tz.utc),
+                },
+            ],
+        ]
+
+        result = await medicine_service.get_today_schedule("p_test01", "u_test01", "2026-04-09")
+        assert len(result.scheduled_items) == 1
+        assert result.scheduled_items[0].is_done is True
+        assert result.scheduled_items[0].administered_by_name == "David"
+        assert result.summary["completed"] == 1
+
+    @pytest.mark.asyncio
+    async def test_non_dosing_day_returns_empty(self, medicine_service, mock_db):
+        mock_db.read_one.side_effect = [
+            {"group_id": "grp_test"},
+            _role_row("viewer"),
+        ]
+        mock_db.read.side_effect = [
+            [  # courses — every 2 days starting Apr 9
+                {
+                    "id": "tc_001",
+                    "pet_id": "p_test01",
+                    "medication_id": "med_001",
+                    "medication_name": "Amlodipine",
+                    "medication_type": "oral",
+                    "group_id": "grp_test",
+                    "dosage": 1.0,
+                    "dosage_unit": "tablet",
+                    "frequency_days": 2,
+                    "times_per_day": ["morning"],
+                    "start_date": date(2026, 4, 9),
+                    "end_date": None,
+                },
+            ],
+            [],  # logs
+        ]
+
+        # Apr 10 is day 1 (not dosing day for freq=2)
+        result = await medicine_service.get_today_schedule("p_test01", "u_viewer", "2026-04-10")
+        assert len(result.scheduled_items) == 0
+        assert result.summary["total_scheduled"] == 0
+
+    @pytest.mark.asyncio
+    async def test_all_day_item_marked_done_with_any_log(self, medicine_service, mock_db):
+        mock_db.read_one.side_effect = [
+            {"group_id": "grp_test"},
+            _role_row("member"),
+        ]
+        mock_db.read.side_effect = [
+            [  # courses with all_day
+                {
+                    "id": "tc_001",
+                    "pet_id": "p_test01",
+                    "medication_id": "med_001",
+                    "medication_name": "Eye Drops",
+                    "medication_type": "eye_drops",
+                    "group_id": "grp_test",
+                    "dosage": 2.0,
+                    "dosage_unit": "drops",
+                    "frequency_days": 1,
+                    "times_per_day": ["all_day"],
+                    "start_date": date(2026, 4, 1),
+                    "end_date": None,
+                },
+            ],
+            [  # log — no time_of_day set but course_id matches
+                {
+                    "id": "mlog_002",
+                    "pet_id": "p_test01",
+                    "medication_id": "med_001",
+                    "group_id": "grp_test",
+                    "course_id": "tc_001",
+                    "dosage": 2.0,
+                    "dosage_unit": "drops",
+                    "time_of_day": None,
+                    "administered_at": dt(2026, 4, 9, 14, 0, tzinfo=tz.utc),
+                    "administered_by": "u_test01",
+                    "administered_by_name": "David",
+                    "notes": None,
+                    "is_active": True,
+                    "created_at": dt(2026, 4, 9, 14, 0, tzinfo=tz.utc),
+                    "updated_at": dt(2026, 4, 9, 14, 0, tzinfo=tz.utc),
+                },
+            ],
+        ]
+
+        result = await medicine_service.get_today_schedule("p_test01", "u_test01", "2026-04-09")
+        assert len(result.scheduled_items) == 1
+        assert result.scheduled_items[0].time_of_day == "all_day"
+        assert result.scheduled_items[0].is_done is True
+
+    @pytest.mark.asyncio
+    async def test_stranger_cannot_view_schedule(self, medicine_service, mock_db):
+        mock_db.read_one.side_effect = [
+            {"group_id": "grp_test"},
+            None,  # not a group member
+        ]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await medicine_service.get_today_schedule("p_test01", "u_stranger", "2026-04-09")
+        assert exc_info.value.status_code == 403

--- a/database/db_schema.sql
+++ b/database/db_schema.sql
@@ -313,3 +313,109 @@ create trigger update_meals_updated_at before
 update
     on
     public.meals for each row execute function update_updated_at_column();
+
+
+-- ================== Medicine Domain ==================
+
+create type medication_type_enum as enum ('oral', 'topical', 'injection', 'eye_drops', 'ear_drops', 'other');
+create type dosage_unit_enum as enum ('tablet', 'ml', 'mg', 'drops', 'puff', 'unit', 'application');
+create type time_of_day_enum as enum ('all_day', 'morning', 'afternoon', 'evening');
+
+
+-- medications table (group-scoped medication catalog)
+CREATE TABLE medications (
+	id varchar(11) NOT NULL,
+	group_id varchar(8) NOT NULL,
+	"name" varchar(100) NOT NULL,
+	medication_type medication_type_enum NOT NULL,
+	default_dosage numeric(7, 2) NULL,
+	dosage_unit dosage_unit_enum NOT NULL,
+	notes text NULL,
+	creator_id varchar(8) NULL,
+	is_active bool DEFAULT true NOT NULL,
+	created_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	updated_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	CONSTRAINT medications_pkey PRIMARY KEY (id),
+	CONSTRAINT medications_notes_check CHECK (length(notes) <= 500),
+	CONSTRAINT fk_medications_group FOREIGN KEY (group_id) REFERENCES public."groups"(id) ON DELETE CASCADE,
+	CONSTRAINT fk_medications_creator FOREIGN KEY (creator_id) REFERENCES public.users(id) ON DELETE SET NULL
+);
+CREATE INDEX idx_medications_group_id ON public.medications USING btree (group_id) WHERE (is_active = true);
+
+create trigger update_medications_updated_at before
+update
+    on
+    public.medications for each row execute function update_updated_at_column();
+
+
+-- treatment_courses table (open-ended recurring schedules)
+CREATE TABLE treatment_courses (
+	id varchar(11) NOT NULL,
+	pet_id varchar(8) NOT NULL,
+	medication_id varchar(11) NOT NULL,
+	group_id varchar(8) NOT NULL,
+	dosage numeric(7, 2) NOT NULL,
+	dosage_unit dosage_unit_enum NOT NULL,
+	frequency_days int NOT NULL DEFAULT 1,
+	times_per_day time_of_day_enum[] NOT NULL DEFAULT '{morning}',
+	start_date date NOT NULL,
+	end_date date NULL,
+	notes text NULL,
+	created_by varchar(8) NULL,
+	is_active bool DEFAULT true NOT NULL,
+	created_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	updated_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	CONSTRAINT treatment_courses_pkey PRIMARY KEY (id),
+	CONSTRAINT treatment_courses_frequency_valid CHECK (frequency_days >= 1 AND frequency_days <= 365),
+	CONSTRAINT treatment_courses_dosage_valid CHECK (dosage > 0),
+	CONSTRAINT treatment_courses_notes_check CHECK (length(notes) <= 500),
+	CONSTRAINT fk_tc_pet FOREIGN KEY (pet_id) REFERENCES public.pets(id) ON DELETE CASCADE,
+	CONSTRAINT fk_tc_medication FOREIGN KEY (medication_id) REFERENCES public.medications(id) ON DELETE CASCADE,
+	CONSTRAINT fk_tc_group FOREIGN KEY (group_id) REFERENCES public."groups"(id) ON DELETE CASCADE,
+	CONSTRAINT fk_tc_creator FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL
+);
+CREATE INDEX idx_tc_pet_id ON public.treatment_courses USING btree (pet_id) WHERE (is_active = true);
+CREATE INDEX idx_tc_group_id ON public.treatment_courses USING btree (group_id) WHERE (is_active = true);
+CREATE INDEX idx_tc_medication_id ON public.treatment_courses USING btree (medication_id) WHERE (is_active = true);
+
+create trigger update_treatment_courses_updated_at before
+update
+    on
+    public.treatment_courses for each row execute function update_updated_at_column();
+
+
+-- medication_logs table (actual administration records)
+CREATE TABLE medication_logs (
+	id varchar(11) NOT NULL,
+	pet_id varchar(8) NOT NULL,
+	medication_id varchar(11) NOT NULL,
+	group_id varchar(8) NOT NULL,
+	course_id varchar(11) NULL,
+	dosage numeric(7, 2) NOT NULL,
+	dosage_unit dosage_unit_enum NOT NULL,
+	time_of_day time_of_day_enum NULL,
+	administered_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	administered_by varchar(8) NULL,
+	notes text NULL,
+	is_active bool DEFAULT true NOT NULL,
+	created_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	updated_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	CONSTRAINT medication_logs_pkey PRIMARY KEY (id),
+	CONSTRAINT medication_logs_dosage_valid CHECK (dosage > 0),
+	CONSTRAINT medication_logs_notes_check CHECK (length(notes) <= 500),
+	CONSTRAINT fk_ml_pet FOREIGN KEY (pet_id) REFERENCES public.pets(id) ON DELETE CASCADE,
+	CONSTRAINT fk_ml_medication FOREIGN KEY (medication_id) REFERENCES public.medications(id) ON DELETE CASCADE,
+	CONSTRAINT fk_ml_group FOREIGN KEY (group_id) REFERENCES public."groups"(id) ON DELETE CASCADE,
+	CONSTRAINT fk_ml_course FOREIGN KEY (course_id) REFERENCES public.treatment_courses(id) ON DELETE SET NULL,
+	CONSTRAINT fk_ml_user FOREIGN KEY (administered_by) REFERENCES public.users(id) ON DELETE SET NULL
+);
+CREATE INDEX idx_ml_pet_id ON public.medication_logs USING btree (pet_id) WHERE (is_active = true);
+CREATE INDEX idx_ml_group_id ON public.medication_logs USING btree (group_id) WHERE (is_active = true);
+CREATE INDEX idx_ml_course_id ON public.medication_logs USING btree (course_id) WHERE (is_active = true);
+CREATE INDEX idx_ml_administered_at ON public.medication_logs USING btree (administered_at) WHERE (is_active = true);
+CREATE INDEX idx_ml_pet_administered ON public.medication_logs USING btree (pet_id, administered_at) WHERE (is_active = true);
+
+create trigger update_medication_logs_updated_at before
+update
+    on
+    public.medication_logs for each row execute function update_updated_at_column();


### PR DESCRIPTION
Closes #91

## Summary
- Add complete medicine domain with 3 new DB tables (medications, treatment_courses, medication_logs) and 3 enums
- Implement MedicineService with treatment course scheduling logic (is_dosing_day), today's schedule assembly, and full CRUD for medications, courses, and logs
- Add 12 endpoints under /medicine prefix (GET/POST only, group-based authorization)
- Bootstrap 28 unit tests covering CRUD, authorization, dosing logic, and today's schedule

## Files changed by layer
- **Models**: backend/models/medicine.py — enums (MedicationType, DosageUnit, TimeOfDay), request/response Pydantic models
- **Services**: backend/services/medicine_service.py — CRUD, is_dosing_day(), get_today_schedule(), permission helpers
- **Routers**: backend/routers/medicine_router.py — 12 endpoints with route ordering to avoid path-param shadowing
- **App**: backend/main.py — register medicine_router
- **Schema**: database/db_schema.sql — 3 enums + 3 tables + triggers + indexes
- **Tests**: backend/tests/unit/test_medicine_service.py — 28 unit tests

## Manual test plan
```bash
# Create a medication
curl -X POST localhost:8000/medicine/create \
  -H "Authorization: Bearer <jwt>" \
  -H "Content-Type: application/json" \
  -d '{"group_id":"<grp>","name":"Amlodipine","medication_type":"oral","dosage_unit":"tablet","default_dosage":1.0}'

# Create a treatment course (daily, morning+evening)
curl -X POST localhost:8000/medicine/course/create \
  -H "Authorization: Bearer <jwt>" \
  -H "Content-Type: application/json" \
  -d '{"pet_id":"<pet>","medication_id":"<med>","group_id":"<grp>","dosage":1.0,"dosage_unit":"tablet","frequency_days":1,"times_per_day":["morning","evening"],"start_date":"2026-04-09"}'

# Check today's schedule
curl "localhost:8000/medicine/today?pet_id=<pet>&local_date=2026-04-09" \
  -H "Authorization: Bearer <jwt>"

# Log a dose
curl -X POST localhost:8000/medicine/log/create \
  -H "Authorization: Bearer <jwt>" \
  -H "Content-Type: application/json" \
  -d '{"pet_id":"<pet>","medication_id":"<med>","group_id":"<grp>","course_id":"<tc>","dosage":1.0,"dosage_unit":"tablet","time_of_day":"morning"}'
```

## Manual SQL to run
```sql
-- Run the entire medicine section from database/db_schema.sql (lines 320-416)
-- against staging and prod. The 3 enums must be created before the 3 tables.

CREATE TYPE medication_type_enum AS ENUM ('oral', 'topical', 'injection', 'eye_drops', 'ear_drops', 'other');
CREATE TYPE dosage_unit_enum AS ENUM ('tablet', 'ml', 'mg', 'drops', 'puff', 'unit', 'application');
CREATE TYPE time_of_day_enum AS ENUM ('all_day', 'morning', 'afternoon', 'evening');

-- Then CREATE TABLE medications, treatment_courses, medication_logs
-- (full SQL in the diff — copy from database/db_schema.sql lines 333-416)
```

## Pre-existing coverage gaps
- No update_course happy-path test (P1 — the update logic with frequency reset is complex)
- No ad-hoc log test in get_today_schedule (P2 — ad_hoc_logs path)

## Notes
- Route ordering in medicine_router.py: static paths (/today, /list, /create, /course/*, /log/*) are declared before /{medication_id} to avoid FastAPI path-param shadowing
- times_per_day uses Postgres enum array (time_of_day_enum[]) — asyncpg handles this natively with $N::time_of_day_enum[] casting
- When frequency_days is updated, start_date resets to the client's local_date so the cycle restarts cleanly