### PR TITLE
[#92] Add medicine page — treatment checklist, course management, and medication database UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,10 +5,10 @@ import { LoginPage } from './components/auth/LoginPage';
 import { SignUpPage } from './components/auth/SignupPage';
 import { DashboardPage } from './components/dashboard';
 import { MainLayout } from './components/layout/MainLayout';
-import { ComingSoon } from './components/common/ComingSoon';
 import { SettingsPage } from './components/settings';
 import { WeightPage } from './components/weight';
 import { MealPage } from './components/meal';
+import { MedicinePage } from './components/medicine';
 import type { NavigationTab } from './types';
 
 // Loading component
@@ -94,12 +94,7 @@ const AppLayout: React.FC = () => {
         />
         <Route
           path="/medicine"
-          element={
-            <ComingSoon
-              title="Medicine Management"
-              description="Keep track of medications, set reminders, and log when medicines are given."
-            />
-          }
+          element={<MedicinePage />}
         />
         <Route
           path="/weight"

--- a/frontend/src/api/services/MedicineService.ts
+++ b/frontend/src/api/services/MedicineService.ts
@@ -1,0 +1,95 @@
+import { apiClient } from '../client';
+import type {
+  CreateMedicationRequest,
+  UpdateMedicationRequest,
+  CreateCourseRequest,
+  UpdateCourseRequest,
+  CreateLogRequest,
+  MedicationInfo,
+  TreatmentCourseInfo,
+  MedicationLogInfo,
+  TodayScheduleResponse,
+  ApiResponse,
+} from '../../types';
+
+class MedicineService {
+  private basePath = '/medicine';
+
+  // ===== Medication CRUD =====
+
+  async createMedication(request: CreateMedicationRequest): Promise<ApiResponse<MedicationInfo>> {
+    const response = await apiClient.post(`${this.basePath}/create`, request);
+    return response.data;
+  }
+
+  async listMedications(groupId: string): Promise<ApiResponse<MedicationInfo[]>> {
+    const response = await apiClient.get(`${this.basePath}/list`, { params: { group_id: groupId } });
+    return response.data;
+  }
+
+  async getMedication(medicationId: string): Promise<ApiResponse<MedicationInfo>> {
+    const response = await apiClient.get(`${this.basePath}/${medicationId}`);
+    return response.data;
+  }
+
+  async updateMedication(medicationId: string, request: UpdateMedicationRequest): Promise<ApiResponse<MedicationInfo>> {
+    const response = await apiClient.post(`${this.basePath}/${medicationId}/update`, request);
+    return response.data;
+  }
+
+  async deleteMedication(medicationId: string): Promise<ApiResponse<{ id: string; deleted: boolean }>> {
+    const response = await apiClient.post(`${this.basePath}/${medicationId}/delete`);
+    return response.data;
+  }
+
+  // ===== Treatment Course =====
+
+  async createCourse(request: CreateCourseRequest): Promise<ApiResponse<TreatmentCourseInfo>> {
+    const response = await apiClient.post(`${this.basePath}/course/create`, request);
+    return response.data;
+  }
+
+  async updateCourse(courseId: string, request: UpdateCourseRequest): Promise<ApiResponse<TreatmentCourseInfo>> {
+    const response = await apiClient.post(`${this.basePath}/course/${courseId}/update`, request);
+    return response.data;
+  }
+
+  async endCourse(courseId: string, localDate?: string): Promise<ApiResponse<TreatmentCourseInfo>> {
+    const response = await apiClient.post(
+      `${this.basePath}/course/${courseId}/end`,
+      null,
+      { params: localDate ? { local_date: localDate } : {} },
+    );
+    return response.data;
+  }
+
+  async listCourses(petId: string, status?: string): Promise<ApiResponse<TreatmentCourseInfo[]>> {
+    const response = await apiClient.get(`${this.basePath}/course/list`, {
+      params: { pet_id: petId, status: status || 'active' },
+    });
+    return response.data;
+  }
+
+  // ===== Medication Log =====
+
+  async createLog(request: CreateLogRequest): Promise<ApiResponse<MedicationLogInfo>> {
+    const response = await apiClient.post(`${this.basePath}/log/create`, request);
+    return response.data;
+  }
+
+  async deleteLog(logId: string): Promise<ApiResponse<{ id: string; deleted: boolean }>> {
+    const response = await apiClient.post(`${this.basePath}/log/${logId}/delete`);
+    return response.data;
+  }
+
+  // ===== Today's Schedule =====
+
+  async getTodaySchedule(petId: string, localDate?: string): Promise<ApiResponse<TodayScheduleResponse>> {
+    const response = await apiClient.get(`${this.basePath}/today`, {
+      params: { pet_id: petId, ...(localDate ? { local_date: localDate } : {}) },
+    });
+    return response.data;
+  }
+}
+
+export const medicineService = new MedicineService();

--- a/frontend/src/api/services/index.ts
+++ b/frontend/src/api/services/index.ts
@@ -5,3 +5,4 @@ export * from './GroupService';
 export * from './WeightService';
 export * from './MealService';
 export * from './FoodService';
+export * from './MedicineService';

--- a/frontend/src/components/forms/CourseDetailsModal.tsx
+++ b/frontend/src/components/forms/CourseDetailsModal.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from 'react';
+import { X, CalendarDays, Clock, Loader2 } from 'lucide-react';
+import { getMedicationTypeConfig, TIME_OF_DAY_LABELS, DOSAGE_UNIT_LABELS } from '../../constants/medicationTypes';
+import type { TreatmentCourseInfo } from '../../types';
+
+interface CourseDetailsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  course: TreatmentCourseInfo | null;
+  canEdit: boolean;
+  onEndCourse: (courseId: string) => Promise<void>;
+}
+
+export const CourseDetailsModal: React.FC<CourseDetailsModalProps> = ({
+  isOpen,
+  onClose,
+  course,
+  canEdit,
+  onEndCourse,
+}) => {
+  const [isEnding, setIsEnding] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  if (!isOpen || !course) return null;
+
+  const config = getMedicationTypeConfig(course.medication_type);
+  const Icon = config.icon;
+  const timesLabel = course.times_per_day.map((t) => TIME_OF_DAY_LABELS[t] || t).join(', ');
+  const freqLabel = course.frequency_days === 1 ? 'Every day' : `Every ${course.frequency_days} days`;
+  const isEnded = !!course.end_date && new Date(course.end_date) < new Date();
+
+  const handleEnd = async () => {
+    setIsEnding(true);
+    try {
+      await onEndCourse(course.id);
+      onClose();
+    } catch {
+      // Error handled by parent
+    } finally {
+      setIsEnding(false);
+      setShowConfirm(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <div className="bg-surface-2 rounded-2xl border border-border-default shadow-elevated max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="flex items-center justify-between p-5 border-b border-border-subtle">
+          <h2 className="text-lg font-bold text-text-primary">Treatment Details</h2>
+          <button onClick={onClose} className="p-2 text-text-tertiary hover:text-text-primary hover:bg-surface-3 rounded-full transition-colors">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-5 space-y-4">
+          {/* Medication info */}
+          <div className="flex items-center gap-3">
+            <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${config.bgClass}`}>
+              <Icon className={`w-6 h-6 ${config.textClass}`} />
+            </div>
+            <div>
+              <p className="text-base font-semibold text-text-primary">{course.medication_name}</p>
+              <span className={`text-xs px-2 py-0.5 rounded ${config.bgClass} ${config.textClass}`}>
+                {config.label}
+              </span>
+            </div>
+          </div>
+
+          {/* Details grid */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between py-2 border-b border-border-subtle">
+              <span className="text-sm text-text-tertiary">Pet</span>
+              <span className="text-sm font-medium text-text-primary">{course.pet_name}</span>
+            </div>
+            <div className="flex items-center justify-between py-2 border-b border-border-subtle">
+              <span className="text-sm text-text-tertiary">Dosage</span>
+              <span className="text-sm font-medium text-text-primary">
+                {course.dosage} {DOSAGE_UNIT_LABELS[course.dosage_unit] || course.dosage_unit}
+              </span>
+            </div>
+            <div className="flex items-center justify-between py-2 border-b border-border-subtle">
+              <span className="text-sm text-text-tertiary flex items-center gap-1">
+                <Clock className="w-3.5 h-3.5" /> Frequency
+              </span>
+              <span className="text-sm font-medium text-text-primary">{freqLabel}</span>
+            </div>
+            <div className="flex items-center justify-between py-2 border-b border-border-subtle">
+              <span className="text-sm text-text-tertiary">Time Slots</span>
+              <span className="text-sm font-medium text-text-primary">{timesLabel}</span>
+            </div>
+            <div className="flex items-center justify-between py-2 border-b border-border-subtle">
+              <span className="text-sm text-text-tertiary flex items-center gap-1">
+                <CalendarDays className="w-3.5 h-3.5" /> Start
+              </span>
+              <span className="text-sm font-medium text-text-primary">{course.start_date}</span>
+            </div>
+            {course.end_date && (
+              <div className="flex items-center justify-between py-2 border-b border-border-subtle">
+                <span className="text-sm text-text-tertiary flex items-center gap-1">
+                  <CalendarDays className="w-3.5 h-3.5" /> End
+                </span>
+                <span className="text-sm font-medium text-text-primary">{course.end_date}</span>
+              </div>
+            )}
+            {course.notes && (
+              <div className="py-2">
+                <span className="text-sm text-text-tertiary">Notes</span>
+                <p className="text-sm text-text-primary mt-1">{course.notes}</p>
+              </div>
+            )}
+            {course.created_by_name && (
+              <div className="flex items-center justify-between py-2">
+                <span className="text-sm text-text-tertiary">Created by</span>
+                <span className="text-sm text-text-secondary">{course.created_by_name}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="p-5 border-t border-border-subtle space-y-2">
+          {canEdit && !isEnded && !showConfirm && (
+            <button
+              onClick={() => setShowConfirm(true)}
+              className="w-full py-2.5 rounded-xl border border-danger/30 text-danger text-sm font-medium hover:bg-danger/10 transition-colors"
+            >
+              End Treatment
+            </button>
+          )}
+          {showConfirm && (
+            <div className="bg-danger/5 border border-danger/20 rounded-xl p-3 space-y-2">
+              <p className="text-sm text-danger">End this treatment course? This will stop it from appearing in today's schedule.</p>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setShowConfirm(false)}
+                  disabled={isEnding}
+                  className="btn-secondary flex-1 py-2 text-sm"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleEnd}
+                  disabled={isEnding}
+                  className="flex-1 py-2 rounded-xl bg-danger text-white text-sm font-medium hover:bg-danger/90 transition-colors flex items-center justify-center gap-2"
+                >
+                  {isEnding ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+                  {isEnding ? 'Ending...' : 'Confirm End'}
+                </button>
+              </div>
+            </div>
+          )}
+          <button onClick={onClose} className="btn-secondary w-full py-2.5">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/forms/CreateCourseForm.tsx
+++ b/frontend/src/components/forms/CreateCourseForm.tsx
@@ -1,0 +1,246 @@
+import React, { useState } from 'react';
+import { X, Stethoscope, Loader2 } from 'lucide-react';
+import { TIME_OF_DAY_LABELS, DOSAGE_UNIT_LABELS } from '../../constants/medicationTypes';
+import type { MedicationInfo, DosageUnit, TimeOfDay } from '../../types';
+
+interface CreateCourseFormProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: {
+    medication_id: string;
+    dosage: number;
+    dosage_unit: DosageUnit;
+    frequency_days: number;
+    times_per_day: TimeOfDay[];
+    start_date: string;
+    notes?: string;
+  }) => Promise<void>;
+  medications: MedicationInfo[];
+}
+
+const TIME_OPTIONS: TimeOfDay[] = ['morning', 'afternoon', 'evening', 'all_day'];
+
+export const CreateCourseForm: React.FC<CreateCourseFormProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  medications,
+}) => {
+  const [medicationId, setMedicationId] = useState('');
+  const [dosage, setDosage] = useState('');
+  const [dosageUnit, setDosageUnit] = useState<DosageUnit>('tablet');
+  const [frequencyDays, setFrequencyDays] = useState('1');
+  const [timesPerDay, setTimesPerDay] = useState<TimeOfDay[]>(['morning']);
+  const [startDate, setStartDate] = useState(new Date().toLocaleDateString('en-CA'));
+  const [notes, setNotes] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleMedicationChange = (id: string) => {
+    setMedicationId(id);
+    const med = medications.find((m) => m.id === id);
+    if (med) {
+      if (med.default_dosage) setDosage(med.default_dosage.toString());
+      setDosageUnit(med.dosage_unit);
+    }
+  };
+
+  const toggleTime = (time: TimeOfDay) => {
+    if (time === 'all_day') {
+      setTimesPerDay(['all_day']);
+      return;
+    }
+    // Deselect all_day when picking specific times
+    const filtered = timesPerDay.filter((t) => t !== 'all_day');
+    if (filtered.includes(time)) {
+      const next = filtered.filter((t) => t !== time);
+      setTimesPerDay(next.length > 0 ? next : ['morning']);
+    } else {
+      setTimesPerDay([...filtered, time]);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!medicationId) {
+      setError('Please select a medication');
+      return;
+    }
+    if (!dosage || parseFloat(dosage) <= 0) {
+      setError('Please enter a valid dosage');
+      return;
+    }
+    setIsSubmitting(true);
+    setError('');
+    try {
+      await onSubmit({
+        medication_id: medicationId,
+        dosage: parseFloat(dosage),
+        dosage_unit: dosageUnit,
+        frequency_days: parseInt(frequencyDays) || 1,
+        times_per_day: timesPerDay,
+        start_date: startDate,
+        notes: notes.trim() || undefined,
+      });
+      handleClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create course');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    setMedicationId('');
+    setDosage('');
+    setDosageUnit('tablet');
+    setFrequencyDays('1');
+    setTimesPerDay(['morning']);
+    setStartDate(new Date().toLocaleDateString('en-CA'));
+    setNotes('');
+    setError('');
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <div className="bg-surface-2 rounded-2xl border border-border-default shadow-elevated max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="flex items-center justify-between p-5 border-b border-border-subtle">
+          <div className="flex items-center gap-2">
+            <Stethoscope className="w-5 h-5 text-accent-purple" />
+            <h2 className="text-lg font-bold text-text-primary">New Treatment Course</h2>
+          </div>
+          <button onClick={handleClose} disabled={isSubmitting} className="p-2 text-text-tertiary hover:text-text-primary hover:bg-surface-3 rounded-full transition-colors">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-5 space-y-4">
+          {error && (
+            <div className="bg-danger/10 border border-danger/30 rounded-xl p-3">
+              <p className="text-danger text-sm">{error}</p>
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-1">Medication *</label>
+            <select
+              value={medicationId}
+              onChange={(e) => handleMedicationChange(e.target.value)}
+              className="input-field"
+              disabled={isSubmitting}
+            >
+              <option value="">Select a medication...</option>
+              {medications.map((med) => (
+                <option key={med.id} value={med.id}>{med.name}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-text-secondary mb-1">Dosage *</label>
+              <input
+                type="number"
+                step="0.1"
+                min="0.1"
+                value={dosage}
+                onChange={(e) => setDosage(e.target.value)}
+                className="input-field"
+                placeholder="0.0"
+                disabled={isSubmitting}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-text-secondary mb-1">Unit</label>
+              <select
+                value={dosageUnit}
+                onChange={(e) => setDosageUnit(e.target.value as DosageUnit)}
+                className="input-field"
+                disabled={isSubmitting}
+              >
+                {Object.entries(DOSAGE_UNIT_LABELS).map(([key, label]) => (
+                  <option key={key} value={key}>{label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-1">
+              Frequency (every N days) *
+            </label>
+            <input
+              type="number"
+              min="1"
+              max="365"
+              value={frequencyDays}
+              onChange={(e) => setFrequencyDays(e.target.value)}
+              className="input-field"
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-2">Time of Day *</label>
+            <div className="grid grid-cols-2 gap-2">
+              {TIME_OPTIONS.map((time) => {
+                const isSelected = timesPerDay.includes(time);
+                return (
+                  <button
+                    key={time}
+                    type="button"
+                    onClick={() => toggleTime(time)}
+                    className={`py-2 px-3 rounded-xl border text-sm transition-colors ${
+                      isSelected
+                        ? 'bg-accent-purple/15 border-accent-purple/30 text-accent-purple'
+                        : 'border-border-subtle text-text-tertiary hover:border-border-default'
+                    }`}
+                  >
+                    {TIME_OF_DAY_LABELS[time]}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-1">Start Date *</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="input-field"
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-1">Notes</label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={2}
+              className="input-field resize-none"
+              placeholder="Treatment notes..."
+              maxLength={500}
+              disabled={isSubmitting}
+            />
+          </div>
+        </form>
+
+        <div className="flex gap-3 p-5 border-t border-border-subtle">
+          <button type="button" onClick={handleClose} disabled={isSubmitting} className="btn-secondary flex-1 py-2.5">
+            Cancel
+          </button>
+          <button onClick={handleSubmit} disabled={isSubmitting} className="btn-primary flex-1 py-2.5 flex items-center justify-center gap-2">
+            {isSubmitting ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+            {isSubmitting ? 'Creating...' : 'Start Treatment'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/forms/CreateMedicationForm.tsx
+++ b/frontend/src/components/forms/CreateMedicationForm.tsx
@@ -1,0 +1,194 @@
+import React, { useState } from 'react';
+import { X, Pill, Loader2 } from 'lucide-react';
+import { MEDICATION_TYPES, DOSAGE_UNIT_LABELS } from '../../constants/medicationTypes';
+import type { MedicationType, DosageUnit } from '../../types';
+
+interface CreateMedicationFormProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: {
+    name: string;
+    medication_type: MedicationType;
+    default_dosage?: number;
+    dosage_unit: DosageUnit;
+    notes?: string;
+  }) => Promise<void>;
+  editData?: {
+    name: string;
+    medication_type: MedicationType;
+    default_dosage?: number | null;
+    dosage_unit: DosageUnit;
+    notes?: string | null;
+  };
+  title?: string;
+}
+
+export const CreateMedicationForm: React.FC<CreateMedicationFormProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  editData,
+  title = 'Add Medication',
+}) => {
+  const [name, setName] = useState(editData?.name || '');
+  const [medicationType, setMedicationType] = useState<MedicationType>(editData?.medication_type || 'oral');
+  const [defaultDosage, setDefaultDosage] = useState<string>(editData?.default_dosage?.toString() || '');
+  const [dosageUnit, setDosageUnit] = useState<DosageUnit>(editData?.dosage_unit || 'tablet');
+  const [notes, setNotes] = useState(editData?.notes || '');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError('Medication name is required');
+      return;
+    }
+    setIsSubmitting(true);
+    setError('');
+    try {
+      await onSubmit({
+        name: name.trim(),
+        medication_type: medicationType,
+        default_dosage: defaultDosage ? parseFloat(defaultDosage) : undefined,
+        dosage_unit: dosageUnit,
+        notes: notes.trim() || undefined,
+      });
+      handleClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save medication');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    setName('');
+    setMedicationType('oral');
+    setDefaultDosage('');
+    setDosageUnit('tablet');
+    setNotes('');
+    setError('');
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  const medTypeEntries = Object.entries(MEDICATION_TYPES) as [MedicationType, typeof MEDICATION_TYPES[MedicationType]][];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <div className="bg-surface-2 rounded-2xl border border-border-default shadow-elevated max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="flex items-center justify-between p-5 border-b border-border-subtle">
+          <div className="flex items-center gap-2">
+            <Pill className="w-5 h-5 text-accent-pink" />
+            <h2 className="text-lg font-bold text-text-primary">{title}</h2>
+          </div>
+          <button onClick={handleClose} disabled={isSubmitting} className="p-2 text-text-tertiary hover:text-text-primary hover:bg-surface-3 rounded-full transition-colors">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-5 space-y-4">
+          {error && (
+            <div className="bg-danger/10 border border-danger/30 rounded-xl p-3">
+              <p className="text-danger text-sm">{error}</p>
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-1">Medication Name *</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="input-field"
+              placeholder="e.g., Amoxicillin"
+              maxLength={100}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-2">Type *</label>
+            <div className="grid grid-cols-3 gap-2">
+              {medTypeEntries.map(([key, config]) => {
+                const Icon = config.icon;
+                const isSelected = medicationType === key;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setMedicationType(key)}
+                    className={`flex flex-col items-center gap-1 p-2.5 rounded-xl border transition-colors ${
+                      isSelected
+                        ? `${config.bgClass} ${config.borderClass} border`
+                        : 'border-border-subtle hover:border-border-default'
+                    }`}
+                  >
+                    <Icon className={`w-5 h-5 ${isSelected ? config.textClass : 'text-text-tertiary'}`} />
+                    <span className={`text-xs ${isSelected ? config.textClass : 'text-text-tertiary'}`}>
+                      {config.label}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-text-secondary mb-1">Default Dosage</label>
+              <input
+                type="number"
+                step="0.1"
+                min="0"
+                value={defaultDosage}
+                onChange={(e) => setDefaultDosage(e.target.value)}
+                className="input-field"
+                placeholder="0.0"
+                disabled={isSubmitting}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-text-secondary mb-1">Unit *</label>
+              <select
+                value={dosageUnit}
+                onChange={(e) => setDosageUnit(e.target.value as DosageUnit)}
+                className="input-field"
+                disabled={isSubmitting}
+              >
+                {Object.entries(DOSAGE_UNIT_LABELS).map(([key, label]) => (
+                  <option key={key} value={key}>{label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-1">Notes</label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={2}
+              className="input-field resize-none"
+              placeholder="Additional information..."
+              maxLength={500}
+              disabled={isSubmitting}
+            />
+          </div>
+        </form>
+
+        <div className="flex gap-3 p-5 border-t border-border-subtle">
+          <button type="button" onClick={handleClose} disabled={isSubmitting} className="btn-secondary flex-1 py-2.5">
+            Cancel
+          </button>
+          <button onClick={handleSubmit} disabled={isSubmitting} className="btn-primary flex-1 py-2.5 flex items-center justify-center gap-2">
+            {isSubmitting ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+            {isSubmitting ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/medicine/ActiveCoursesList.tsx
+++ b/frontend/src/components/medicine/ActiveCoursesList.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { CalendarDays, Plus, Loader2, Stethoscope } from 'lucide-react';
+import { getMedicationTypeConfig, TIME_OF_DAY_LABELS, DOSAGE_UNIT_LABELS } from '../../constants/medicationTypes';
+import type { TreatmentCourseInfo } from '../../types';
+
+interface ActiveCoursesListProps {
+  courses: TreatmentCourseInfo[];
+  canEdit: boolean;
+  isLoading: boolean;
+  onCourseClick: (course: TreatmentCourseInfo) => void;
+  onAddCourse: () => void;
+}
+
+export const ActiveCoursesList: React.FC<ActiveCoursesListProps> = ({
+  courses,
+  canEdit,
+  isLoading,
+  onCourseClick,
+  onAddCourse,
+}) => {
+  return (
+    <div className="surface-card p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Stethoscope className="w-5 h-5 text-accent-purple" />
+          <h3 className="text-base font-semibold text-text-primary">Active Treatments</h3>
+        </div>
+        {canEdit && (
+          <button
+            onClick={onAddCourse}
+            className="w-8 h-8 rounded-full bg-accent-purple/15 text-accent-purple hover:bg-accent-purple/25 flex items-center justify-center transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {isLoading && courses.length === 0 ? (
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="w-6 h-6 text-accent-purple animate-spin" />
+        </div>
+      ) : courses.length === 0 ? (
+        <div className="text-center py-6">
+          <Stethoscope className="w-10 h-10 text-text-disabled mx-auto mb-2" />
+          <p className="text-sm text-text-tertiary">No active treatments</p>
+          {canEdit && (
+            <button onClick={onAddCourse} className="text-xs text-accent-purple hover:underline mt-1">
+              Start a treatment course
+            </button>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {courses.map((course) => {
+            const config = getMedicationTypeConfig(course.medication_type);
+            const Icon = config.icon;
+            const timesLabel = course.times_per_day
+              .map((t) => TIME_OF_DAY_LABELS[t] || t)
+              .join(' + ');
+            const freqLabel = course.frequency_days === 1
+              ? 'Every day'
+              : `Every ${course.frequency_days} days`;
+
+            return (
+              <button
+                key={course.id}
+                onClick={() => onCourseClick(course)}
+                className="w-full text-left p-3 rounded-xl border border-border-subtle bg-surface-1 hover:bg-surface-2 transition-colors"
+              >
+                <div className="flex items-start gap-3">
+                  <div className={`w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0 ${config.bgClass}`}>
+                    <Icon className={`w-5 h-5 ${config.textClass}`} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-text-primary truncate">
+                      {course.medication_name}
+                    </p>
+                    <p className="text-xs text-text-tertiary mt-0.5">
+                      {course.dosage} {DOSAGE_UNIT_LABELS[course.dosage_unit] || course.dosage_unit} &middot; {freqLabel}
+                    </p>
+                    <div className="flex items-center gap-2 mt-1">
+                      <span className={`text-xs px-1.5 py-0.5 rounded ${config.bgClass} ${config.textClass}`}>
+                        {timesLabel}
+                      </span>
+                      <span className="text-xs text-text-disabled flex items-center gap-1">
+                        <CalendarDays className="w-3 h-3" />
+                        {course.start_date}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/medicine/MedicationDatabase.tsx
+++ b/frontend/src/components/medicine/MedicationDatabase.tsx
@@ -1,0 +1,141 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Plus, MoreVertical, Pencil, Trash2, Loader2, Database } from 'lucide-react';
+import { getMedicationTypeConfig, DOSAGE_UNIT_LABELS } from '../../constants/medicationTypes';
+import type { MedicationInfo } from '../../types';
+
+interface MedicationDatabaseProps {
+  medications: MedicationInfo[];
+  canEdit: boolean;
+  isLoading: boolean;
+  onAddMedication: () => void;
+  onEditMedication: (medication: MedicationInfo) => void;
+  onDeleteMedication: (medication: MedicationInfo) => void;
+}
+
+export const MedicationDatabase: React.FC<MedicationDatabaseProps> = ({
+  medications,
+  canEdit,
+  isLoading,
+  onAddMedication,
+  onEditMedication,
+  onDeleteMedication,
+}) => {
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpenId(null);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  return (
+    <div className="surface-card p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Database className="w-5 h-5 text-accent-blue" />
+          <h3 className="text-base font-semibold text-text-primary">Medication Database</h3>
+        </div>
+        {canEdit && (
+          <button
+            onClick={onAddMedication}
+            className="w-8 h-8 rounded-full bg-accent-blue/15 text-accent-blue hover:bg-accent-blue/25 flex items-center justify-center transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {isLoading && medications.length === 0 ? (
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="w-6 h-6 text-accent-blue animate-spin" />
+        </div>
+      ) : medications.length === 0 ? (
+        <div className="text-center py-6">
+          <Database className="w-10 h-10 text-text-disabled mx-auto mb-2" />
+          <p className="text-sm text-text-tertiary">No medications added yet</p>
+          {canEdit && (
+            <button onClick={onAddMedication} className="text-xs text-accent-blue hover:underline mt-1">
+              Add your first medication
+            </button>
+          )}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3" ref={menuRef}>
+          {medications.map((med) => {
+            const config = getMedicationTypeConfig(med.medication_type);
+            const Icon = config.icon;
+
+            return (
+              <div
+                key={med.id}
+                className="relative bg-surface-1 rounded-xl p-3 border border-border-subtle hover:border-border-default transition-colors"
+              >
+                {canEdit && (
+                  <div className="absolute top-2 right-2">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setMenuOpenId(menuOpenId === med.id ? null : med.id);
+                      }}
+                      className="p-1.5 rounded-lg text-text-tertiary hover:text-text-primary hover:bg-surface-2 transition-colors"
+                    >
+                      <MoreVertical className="w-4 h-4" />
+                    </button>
+                    {menuOpenId === med.id && (
+                      <div className="absolute right-0 mt-1 w-36 bg-surface-3 rounded-xl border border-border-subtle shadow-elevated z-20 overflow-hidden">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setMenuOpenId(null);
+                            onEditMedication(med);
+                          }}
+                          className="w-full flex items-center gap-2 px-3 py-2 text-sm text-text-primary hover:bg-surface-2 transition-colors"
+                        >
+                          <Pencil className="w-3.5 h-3.5" />
+                          Edit
+                        </button>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setMenuOpenId(null);
+                            onDeleteMedication(med);
+                          }}
+                          className="w-full flex items-center gap-2 px-3 py-2 text-sm text-danger hover:bg-surface-2 transition-colors"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                          Delete
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                <div className={`w-12 h-12 rounded-xl flex items-center justify-center mb-2 ${config.bgClass}`}>
+                  <Icon className={`w-6 h-6 ${config.textClass}`} />
+                </div>
+                <p className="text-sm font-medium text-text-primary truncate pr-8">
+                  {med.name}
+                </p>
+                <div className="flex items-center gap-2 mt-1">
+                  <span className={`text-xs px-1.5 py-0.5 rounded ${config.bgClass} ${config.textClass}`}>
+                    {config.label}
+                  </span>
+                  {med.default_dosage != null && (
+                    <span className="text-xs text-text-tertiary">
+                      {med.default_dosage} {DOSAGE_UNIT_LABELS[med.dosage_unit] || med.dosage_unit}
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/medicine/MedicinePage.tsx
+++ b/frontend/src/components/medicine/MedicinePage.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { AlertCircle } from 'lucide-react';
+import { usePet, useMedicine } from '../../hooks';
+import { TodayMedicationChecklist } from './TodayMedicationChecklist';
+import { ActiveCoursesList } from './ActiveCoursesList';
+import { MedicationDatabase } from './MedicationDatabase';
+import { CreateMedicationForm } from '../forms/CreateMedicationForm';
+import { CreateCourseForm } from '../forms/CreateCourseForm';
+import { CourseDetailsModal } from '../forms/CourseDetailsModal';
+import type {
+  ScheduledItem,
+  MedicationInfo,
+  TreatmentCourseInfo,
+  MedicationType,
+  DosageUnit,
+  TimeOfDay,
+} from '../../types';
+
+export const MedicinePage: React.FC = () => {
+  const { selectedPet, userPets } = usePet();
+  const {
+    getMedications,
+    addMedication,
+    editMedication,
+    deleteMedication,
+    getCachedMedications,
+    getCourses,
+    addCourse,
+    endTreatment,
+    getCachedCourses,
+    getTodaySchedule,
+    markDone,
+    undoMarkDone,
+    getCachedTodaySchedule,
+    isLoading,
+  } = useMedicine();
+
+  const pet = selectedPet;
+  const petId = pet?.id;
+  const groupId = pet?.group_id;
+  const petAccess = userPets.find((p) => p.petId === petId);
+  const canEdit = petAccess?.role !== 'Viewer';
+
+  // Modal states
+  const [showMedForm, setShowMedForm] = useState(false);
+  const [showCourseForm, setShowCourseForm] = useState(false);
+  const [selectedCourse, setSelectedCourse] = useState<TreatmentCourseInfo | null>(null);
+  const [editingMed, setEditingMed] = useState<MedicationInfo | null>(null);
+
+  const localDate = new Date().toLocaleDateString('en-CA');
+
+  // Fetch data when pet changes
+  useEffect(() => {
+    if (petId && groupId) {
+      getMedications(groupId);
+      getCourses(petId);
+      getTodaySchedule(petId, localDate);
+    }
+  }, [petId, groupId, getMedications, getCourses, getTodaySchedule, localDate]);
+
+  const medications = groupId ? getCachedMedications(groupId) : [];
+  const courses = petId ? getCachedCourses(petId) : [];
+  const todaySchedule = petId ? getCachedTodaySchedule(petId) : null;
+
+  const medsLoading = groupId ? isLoading(`meds_${groupId}`) : false;
+  const coursesLoading = petId ? isLoading(`courses_${petId}`) : false;
+  const todayLoading = petId ? isLoading(`today_${petId}`) : false;
+
+  const refreshAll = useCallback(() => {
+    if (petId && groupId) {
+      getMedications(groupId);
+      getCourses(petId);
+      getTodaySchedule(petId, localDate);
+    }
+  }, [petId, groupId, getMedications, getCourses, getTodaySchedule, localDate]);
+
+  // ===== Handlers =====
+
+  const handleMarkDone = useCallback(async (item: ScheduledItem) => {
+    if (!petId || !groupId) return;
+    await markDone({
+      pet_id: petId,
+      medication_id: item.medication_id,
+      group_id: groupId,
+      course_id: item.course_id,
+      dosage: item.dosage,
+      dosage_unit: item.dosage_unit as DosageUnit,
+      time_of_day: item.time_of_day as TimeOfDay,
+    });
+    await getTodaySchedule(petId, localDate);
+  }, [petId, groupId, markDone, getTodaySchedule, localDate]);
+
+  const handleUndoMarkDone = useCallback(async (item: ScheduledItem) => {
+    if (!petId || !item.log_id) return;
+    await undoMarkDone(item.log_id, petId);
+    await getTodaySchedule(petId, localDate);
+  }, [petId, undoMarkDone, getTodaySchedule, localDate]);
+
+  const handleAddMedication = useCallback(async (data: {
+    name: string;
+    medication_type: MedicationType;
+    default_dosage?: number;
+    dosage_unit: DosageUnit;
+    notes?: string;
+  }) => {
+    if (!groupId) return;
+    await addMedication({ ...data, group_id: groupId });
+    await getMedications(groupId);
+  }, [groupId, addMedication, getMedications]);
+
+  const handleEditMedication = useCallback(async (data: {
+    name: string;
+    medication_type: MedicationType;
+    default_dosage?: number;
+    dosage_unit: DosageUnit;
+    notes?: string;
+  }) => {
+    if (!groupId || !editingMed) return;
+    await editMedication(editingMed.id, groupId, data);
+    await getMedications(groupId);
+  }, [groupId, editingMed, editMedication, getMedications]);
+
+  const handleDeleteMedication = useCallback(async (med: MedicationInfo) => {
+    if (!groupId) return;
+    if (!window.confirm(`Delete "${med.name}"?`)) return;
+    await deleteMedication(med.id, groupId);
+  }, [groupId, deleteMedication]);
+
+  const handleAddCourse = useCallback(async (data: {
+    medication_id: string;
+    dosage: number;
+    dosage_unit: DosageUnit;
+    frequency_days: number;
+    times_per_day: TimeOfDay[];
+    start_date: string;
+    notes?: string;
+  }) => {
+    if (!petId || !groupId) return;
+    await addCourse({ ...data, pet_id: petId, group_id: groupId });
+    refreshAll();
+  }, [petId, groupId, addCourse, refreshAll]);
+
+  const handleEndCourse = useCallback(async (courseId: string) => {
+    if (!petId) return;
+    await endTreatment(courseId, petId, localDate);
+    refreshAll();
+  }, [petId, endTreatment, localDate, refreshAll]);
+
+  // ===== Render =====
+
+  if (!pet) {
+    return (
+      <div className="p-4 space-y-4">
+        <div className="surface-card p-6 text-center">
+          <AlertCircle className="w-10 h-10 text-text-disabled mx-auto mb-2" />
+          <p className="text-sm text-text-tertiary">No pet selected</p>
+          <p className="text-xs text-text-disabled mt-1">Select a pet from the dashboard to manage medications</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4 lg:p-6">
+      <TodayMedicationChecklist
+        schedule={todaySchedule}
+        groupId={groupId || ''}
+        petId={petId || ''}
+        canEdit={canEdit}
+        onMarkDone={handleMarkDone}
+        onUndoMarkDone={handleUndoMarkDone}
+        isLoading={todayLoading}
+      />
+
+      <ActiveCoursesList
+        courses={courses}
+        canEdit={canEdit}
+        isLoading={coursesLoading}
+        onCourseClick={(course) => setSelectedCourse(course)}
+        onAddCourse={() => setShowCourseForm(true)}
+      />
+
+      <MedicationDatabase
+        medications={medications}
+        canEdit={canEdit}
+        isLoading={medsLoading}
+        onAddMedication={() => setShowMedForm(true)}
+        onEditMedication={(med) => setEditingMed(med)}
+        onDeleteMedication={handleDeleteMedication}
+      />
+
+      {/* Add medication modal */}
+      <CreateMedicationForm
+        isOpen={showMedForm}
+        onClose={() => setShowMedForm(false)}
+        onSubmit={handleAddMedication}
+      />
+
+      {/* Edit medication modal */}
+      {editingMed && (
+        <CreateMedicationForm
+          isOpen={!!editingMed}
+          onClose={() => setEditingMed(null)}
+          onSubmit={handleEditMedication}
+          editData={editingMed}
+          title="Edit Medication"
+        />
+      )}
+
+      {/* Create course modal */}
+      <CreateCourseForm
+        isOpen={showCourseForm}
+        onClose={() => setShowCourseForm(false)}
+        onSubmit={handleAddCourse}
+        medications={medications}
+      />
+
+      {/* Course details modal */}
+      <CourseDetailsModal
+        isOpen={!!selectedCourse}
+        onClose={() => setSelectedCourse(null)}
+        course={selectedCourse}
+        canEdit={canEdit}
+        onEndCourse={handleEndCourse}
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/medicine/TodayMedicationChecklist.tsx
+++ b/frontend/src/components/medicine/TodayMedicationChecklist.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { Check, Clock, Loader2, Undo2, Pill } from 'lucide-react';
+import { getMedicationTypeConfig, TIME_OF_DAY_LABELS, DOSAGE_UNIT_LABELS } from '../../constants/medicationTypes';
+import type { ScheduledItem, TodayScheduleResponse } from '../../types';
+
+interface TodayMedicationChecklistProps {
+  schedule: TodayScheduleResponse | null;
+  groupId: string;
+  petId: string;
+  canEdit: boolean;
+  onMarkDone: (item: ScheduledItem) => Promise<void>;
+  onUndoMarkDone: (item: ScheduledItem) => Promise<void>;
+  isLoading: boolean;
+}
+
+export const TodayMedicationChecklist: React.FC<TodayMedicationChecklistProps> = ({
+  schedule,
+  canEdit,
+  onMarkDone,
+  onUndoMarkDone,
+  isLoading,
+}) => {
+  const [processingId, setProcessingId] = useState<string | null>(null);
+
+  const items = schedule?.scheduled_items || [];
+  const summary = schedule?.summary;
+
+  const handleToggle = async (item: ScheduledItem) => {
+    const key = `${item.course_id}_${item.time_of_day}`;
+    setProcessingId(key);
+    try {
+      if (item.is_done) {
+        await onUndoMarkDone(item);
+      } else {
+        await onMarkDone(item);
+      }
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
+  // Sort: pending first, then done
+  const sortedItems = [...items].sort((a, b) => {
+    if (a.is_done === b.is_done) return 0;
+    return a.is_done ? 1 : -1;
+  });
+
+  return (
+    <div className="surface-card p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Clock className="w-5 h-5 text-accent-teal" />
+          <h3 className="text-base font-semibold text-text-primary">Today's Medications</h3>
+        </div>
+        {summary && summary.total_scheduled > 0 && (
+          <span className="text-xs font-medium text-text-tertiary bg-surface-1 px-2 py-1 rounded-full">
+            {summary.completed}/{summary.total_scheduled}
+          </span>
+        )}
+      </div>
+
+      {isLoading && items.length === 0 ? (
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="w-6 h-6 text-accent-teal animate-spin" />
+        </div>
+      ) : items.length === 0 ? (
+        <div className="text-center py-6">
+          <Pill className="w-10 h-10 text-text-disabled mx-auto mb-2" />
+          <p className="text-sm text-text-tertiary">No medications scheduled for today</p>
+          <p className="text-xs text-text-disabled mt-1">Create a treatment course to get started</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {sortedItems.map((item) => {
+            const config = getMedicationTypeConfig(item.medication_type);
+            const Icon = config.icon;
+            const key = `${item.course_id}_${item.time_of_day}`;
+            const isProcessing = processingId === key;
+
+            return (
+              <div
+                key={key}
+                className={`flex items-center gap-3 p-3 rounded-xl border transition-colors ${
+                  item.is_done
+                    ? 'bg-success/5 border-success/20'
+                    : 'bg-surface-1 border-border-subtle'
+                }`}
+              >
+                <div className={`w-8 h-8 rounded-lg flex items-center justify-center ${config.bgClass}`}>
+                  <Icon className={`w-4 h-4 ${config.textClass}`} />
+                </div>
+
+                <div className="flex-1 min-w-0">
+                  <p className={`text-sm font-medium truncate ${item.is_done ? 'text-text-tertiary line-through' : 'text-text-primary'}`}>
+                    {item.medication_name}
+                  </p>
+                  <div className="flex items-center gap-2 mt-0.5">
+                    <span className="text-xs text-text-tertiary">
+                      {item.dosage} {DOSAGE_UNIT_LABELS[item.dosage_unit] || item.dosage_unit}
+                    </span>
+                    <span className={`text-xs px-1.5 py-0.5 rounded ${config.bgClass} ${config.textClass}`}>
+                      {TIME_OF_DAY_LABELS[item.time_of_day] || item.time_of_day}
+                    </span>
+                  </div>
+                  {item.is_done && item.administered_by_name && (
+                    <p className="text-xs text-success mt-0.5">
+                      Done by {item.administered_by_name}
+                    </p>
+                  )}
+                </div>
+
+                {canEdit && (
+                  <button
+                    onClick={() => handleToggle(item)}
+                    disabled={isProcessing}
+                    className={`w-10 h-10 rounded-full flex items-center justify-center transition-colors flex-shrink-0 ${
+                      item.is_done
+                        ? 'bg-success/15 text-success hover:bg-success/25'
+                        : 'bg-surface-2 text-text-tertiary hover:bg-accent-teal/15 hover:text-accent-teal'
+                    }`}
+                  >
+                    {isProcessing ? (
+                      <Loader2 className="w-5 h-5 animate-spin" />
+                    ) : item.is_done ? (
+                      <Undo2 className="w-4 h-4" />
+                    ) : (
+                      <Check className="w-5 h-5" />
+                    )}
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/medicine/index.ts
+++ b/frontend/src/components/medicine/index.ts
@@ -1,0 +1,1 @@
+export { MedicinePage } from './MedicinePage';

--- a/frontend/src/constants/medicationTypes.ts
+++ b/frontend/src/constants/medicationTypes.ts
@@ -1,0 +1,76 @@
+import { Pill, Droplets, Syringe, Eye, Ear } from 'lucide-react';
+import type { MedicationType } from '../types';
+
+export const MEDICATION_TYPES: Record<
+  MedicationType,
+  {
+    label: string;
+    icon: typeof Pill;
+    bgClass: string;
+    textClass: string;
+    borderClass: string;
+  }
+> = {
+  oral: {
+    label: 'Oral',
+    icon: Pill,
+    bgClass: 'bg-accent-pink/15',
+    textClass: 'text-accent-pink',
+    borderClass: 'border-accent-pink/30',
+  },
+  topical: {
+    label: 'Topical',
+    icon: Droplets,
+    bgClass: 'bg-accent-teal/15',
+    textClass: 'text-accent-teal',
+    borderClass: 'border-accent-teal/30',
+  },
+  injection: {
+    label: 'Injection',
+    icon: Syringe,
+    bgClass: 'bg-accent-purple/15',
+    textClass: 'text-accent-purple',
+    borderClass: 'border-accent-purple/30',
+  },
+  eye_drops: {
+    label: 'Eye Drops',
+    icon: Eye,
+    bgClass: 'bg-accent-blue/15',
+    textClass: 'text-accent-blue',
+    borderClass: 'border-accent-blue/30',
+  },
+  ear_drops: {
+    label: 'Ear Drops',
+    icon: Ear,
+    bgClass: 'bg-accent-pink/15',
+    textClass: 'text-accent-pink',
+    borderClass: 'border-accent-pink/30',
+  },
+  other: {
+    label: 'Other',
+    icon: Pill,
+    bgClass: 'bg-surface-2',
+    textClass: 'text-text-tertiary',
+    borderClass: 'border-border-subtle',
+  },
+};
+
+export const getMedicationTypeConfig = (type: MedicationType) =>
+  MEDICATION_TYPES[type] || MEDICATION_TYPES.other;
+
+export const TIME_OF_DAY_LABELS: Record<string, string> = {
+  all_day: 'All Day',
+  morning: 'Morning',
+  afternoon: 'Afternoon',
+  evening: 'Evening',
+};
+
+export const DOSAGE_UNIT_LABELS: Record<string, string> = {
+  tablet: 'tablet(s)',
+  ml: 'mL',
+  mg: 'mg',
+  drops: 'drop(s)',
+  puff: 'puff(s)',
+  unit: 'unit(s)',
+  application: 'application(s)',
+};

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -32,5 +32,9 @@ export {
 } from './foods';
 
 export {
+  useMedicine
+} from './medicine';
+
+export {
   useRefresh
 } from './useRefresh';

--- a/frontend/src/hooks/medicine/index.ts
+++ b/frontend/src/hooks/medicine/index.ts
@@ -1,0 +1,1 @@
+export { useMedicine } from './useMedicine';

--- a/frontend/src/hooks/medicine/useMedicine.ts
+++ b/frontend/src/hooks/medicine/useMedicine.ts
@@ -1,0 +1,158 @@
+import { useCallback } from 'react';
+import { useAppDispatch, useAppSelector } from '../redux';
+import {
+  fetchMedications,
+  createMedication,
+  updateMedication,
+  deleteMedication as deleteMedicationAction,
+  fetchCourses,
+  createCourse,
+  endCourse,
+  fetchTodaySchedule,
+  createLog,
+  deleteLog as deleteLogAction,
+} from '../../store';
+import type {
+  CreateMedicationRequest,
+  UpdateMedicationRequest,
+  CreateCourseRequest,
+  CreateLogRequest,
+  MedicationInfo,
+  TreatmentCourseInfo,
+  TodayScheduleResponse,
+} from '../../types';
+
+export const useMedicine = () => {
+  const dispatch = useAppDispatch();
+  const medicineState = useAppSelector((state) => state.medicine);
+
+  // ===== Medication operations =====
+
+  const getMedications = useCallback(async (groupId: string) => {
+    const result = await dispatch(fetchMedications({ groupId }));
+    if (fetchMedications.rejected.match(result)) {
+      const payload = result.payload as { groupId: string; error: string };
+      throw new Error(payload.error);
+    }
+  }, [dispatch]);
+
+  const addMedication = useCallback(async (request: CreateMedicationRequest) => {
+    const result = await dispatch(createMedication(request));
+    if (createMedication.rejected.match(result)) {
+      const payload = result.payload as { groupId: string; error: string };
+      throw new Error(payload.error);
+    }
+  }, [dispatch]);
+
+  const editMedication = useCallback(async (medicationId: string, groupId: string, request: UpdateMedicationRequest) => {
+    const result = await dispatch(updateMedication({ medicationId, groupId, request }));
+    if (updateMedication.rejected.match(result)) {
+      const payload = result.payload as { groupId: string; error: string };
+      throw new Error(payload.error);
+    }
+  }, [dispatch]);
+
+  const deleteMedication = useCallback(async (medicationId: string, groupId: string) => {
+    const result = await dispatch(deleteMedicationAction({ medicationId, groupId }));
+    if (deleteMedicationAction.rejected.match(result)) {
+      const payload = result.payload as { groupId: string; error: string };
+      throw new Error(payload.error);
+    }
+  }, [dispatch]);
+
+  const getCachedMedications = useCallback((groupId: string): MedicationInfo[] => {
+    return medicineState.medications[groupId] || [];
+  }, [medicineState.medications]);
+
+  // ===== Course operations =====
+
+  const getCourses = useCallback(async (petId: string, status?: string) => {
+    const result = await dispatch(fetchCourses({ petId, status }));
+    if (fetchCourses.rejected.match(result)) {
+      const payload = result.payload as { petId: string; error: string };
+      throw new Error(payload.error);
+    }
+  }, [dispatch]);
+
+  const addCourse = useCallback(async (request: CreateCourseRequest) => {
+    const result = await dispatch(createCourse(request));
+    if (createCourse.rejected.match(result)) {
+      const payload = result.payload as { petId: string; error: string };
+      throw new Error(payload.error);
+    }
+  }, [dispatch]);
+
+  const endTreatment = useCallback(async (courseId: string, petId: string, localDate?: string) => {
+    const result = await dispatch(endCourse({ courseId, petId, localDate }));
+    if (endCourse.rejected.match(result)) {
+      const payload = result.payload as { petId: string; error: string };
+      throw new Error(payload.error);
+    }
+  }, [dispatch]);
+
+  const getCachedCourses = useCallback((petId: string): TreatmentCourseInfo[] => {
+    return medicineState.courses[petId] || [];
+  }, [medicineState.courses]);
+
+  // ===== Today schedule operations =====
+
+  const getTodaySchedule = useCallback(async (petId: string, localDate?: string) => {
+    const result = await dispatch(fetchTodaySchedule({ petId, localDate }));
+    if (fetchTodaySchedule.rejected.match(result)) {
+      const payload = result.payload as { petId: string; error: string };
+      throw new Error(payload.error);
+    }
+  }, [dispatch]);
+
+  const markDone = useCallback(async (request: CreateLogRequest) => {
+    const result = await dispatch(createLog(request));
+    if (createLog.rejected.match(result)) {
+      const payload = result.payload as { petId: string; error: string };
+      throw new Error(payload.error);
+    }
+  }, [dispatch]);
+
+  const undoMarkDone = useCallback(async (logId: string, petId: string) => {
+    const result = await dispatch(deleteLogAction({ logId, petId }));
+    if (deleteLogAction.rejected.match(result)) {
+      const payload = result.payload as { petId: string; error: string };
+      throw new Error(payload.error);
+    }
+  }, [dispatch]);
+
+  const getCachedTodaySchedule = useCallback((petId: string): TodayScheduleResponse | null => {
+    return medicineState.todaySchedule[petId] || null;
+  }, [medicineState.todaySchedule]);
+
+  // ===== Loading / Error =====
+
+  const isLoading = useCallback((key: string): boolean => {
+    return medicineState.isLoading[key] || false;
+  }, [medicineState.isLoading]);
+
+  const getError = useCallback((key: string): string | null => {
+    return medicineState.error[key] || null;
+  }, [medicineState.error]);
+
+  return {
+    // Medications
+    getMedications,
+    addMedication,
+    editMedication,
+    deleteMedication,
+    getCachedMedications,
+    // Courses
+    getCourses,
+    addCourse,
+    endTreatment,
+    getCachedCourses,
+    // Today schedule
+    getTodaySchedule,
+    markDone,
+    undoMarkDone,
+    getCachedTodaySchedule,
+    // Loading / Error
+    isLoading,
+    getError,
+  };
+};

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -5,6 +5,7 @@ import groupReducer from './slices/groupSlice';
 import weightReducer from './slices/weightSlice';
 import mealReducer from './slices/mealSlice';
 import foodReducer from './slices/foodSlice';
+import medicineReducer from './slices/medicineSlice';
 
 export const store = configureStore({
   reducer: {
@@ -14,6 +15,7 @@ export const store = configureStore({
     weight: weightReducer,
     meal: mealReducer,
     food: foodReducer,
+    medicine: medicineReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
@@ -68,4 +70,18 @@ export {
   clearFoodState,
   clearError as clearFoodError
 } from './slices/foodSlice';
+export {
+  fetchMedications,
+  createMedication,
+  updateMedication,
+  deleteMedication,
+  fetchCourses,
+  createCourse,
+  endCourse,
+  fetchTodaySchedule,
+  createLog,
+  deleteLog,
+  clearMedicineState,
+  clearMedicineError
+} from './slices/medicineSlice';
 export type { PetAccess } from './slices/petSlice';

--- a/frontend/src/store/slices/medicineSlice.ts
+++ b/frontend/src/store/slices/medicineSlice.ts
@@ -1,0 +1,358 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import type {
+  MedicationInfo,
+  TreatmentCourseInfo,
+  TodayScheduleResponse,
+  CreateMedicationRequest,
+  UpdateMedicationRequest,
+  CreateCourseRequest,
+  CreateLogRequest,
+} from '../../types';
+import { medicineService } from '../../api';
+import { logout } from './authSlice';
+
+interface MedicineState {
+  medications: Record<string, MedicationInfo[]>; // groupId -> MedicationInfo[]
+  courses: Record<string, TreatmentCourseInfo[]>; // petId -> TreatmentCourseInfo[]
+  todaySchedule: Record<string, TodayScheduleResponse>; // petId -> TodayScheduleResponse
+  isLoading: Record<string, boolean>; // key -> loading state
+  error: Record<string, string | null>; // key -> error message
+}
+
+const initialState: MedicineState = {
+  medications: {},
+  courses: {},
+  todaySchedule: {},
+  isLoading: {},
+  error: {},
+};
+
+export const fetchMedications = createAsyncThunk(
+  'medicine/fetchMedications',
+  async ({ groupId }: { groupId: string }, { rejectWithValue }) => {
+    try {
+      const response = await medicineService.listMedications(groupId);
+      if (response.status === 1 && response.data) {
+        return { groupId, data: response.data };
+      } else {
+        throw new Error(response.message || 'Failed to fetch medications');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to fetch medications';
+      return rejectWithValue({ groupId, error: message });
+    }
+  },
+);
+
+export const createMedication = createAsyncThunk(
+  'medicine/createMedication',
+  async (request: CreateMedicationRequest, { rejectWithValue }) => {
+    try {
+      const response = await medicineService.createMedication(request);
+      if (response.status === 1 && response.data) {
+        return { groupId: request.group_id, medication: response.data };
+      } else {
+        throw new Error(response.message || 'Failed to create medication');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to create medication';
+      return rejectWithValue({ groupId: request.group_id, error: message });
+    }
+  },
+);
+
+export const updateMedication = createAsyncThunk(
+  'medicine/updateMedication',
+  async (
+    { medicationId, groupId, request }: { medicationId: string; groupId: string; request: UpdateMedicationRequest },
+    { rejectWithValue },
+  ) => {
+    try {
+      const response = await medicineService.updateMedication(medicationId, request);
+      if (response.status === 1 && response.data) {
+        return { groupId, medication: response.data };
+      } else {
+        throw new Error(response.message || 'Failed to update medication');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update medication';
+      return rejectWithValue({ groupId, error: message });
+    }
+  },
+);
+
+export const deleteMedication = createAsyncThunk(
+  'medicine/deleteMedication',
+  async ({ medicationId, groupId }: { medicationId: string; groupId: string }, { rejectWithValue }) => {
+    try {
+      const response = await medicineService.deleteMedication(medicationId);
+      if (response.status === 1) {
+        return { groupId, medicationId };
+      } else {
+        throw new Error(response.message || 'Failed to delete medication');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to delete medication';
+      return rejectWithValue({ groupId, error: message });
+    }
+  },
+);
+
+export const fetchCourses = createAsyncThunk(
+  'medicine/fetchCourses',
+  async ({ petId, status }: { petId: string; status?: string }, { rejectWithValue }) => {
+    try {
+      const response = await medicineService.listCourses(petId, status);
+      if (response.status === 1 && response.data) {
+        return { petId, data: response.data };
+      } else {
+        throw new Error(response.message || 'Failed to fetch courses');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to fetch courses';
+      return rejectWithValue({ petId, error: message });
+    }
+  },
+);
+
+export const createCourse = createAsyncThunk(
+  'medicine/createCourse',
+  async (request: CreateCourseRequest, { rejectWithValue }) => {
+    try {
+      const response = await medicineService.createCourse(request);
+      if (response.status === 1 && response.data) {
+        return { petId: request.pet_id, course: response.data };
+      } else {
+        throw new Error(response.message || 'Failed to create course');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to create course';
+      return rejectWithValue({ petId: request.pet_id, error: message });
+    }
+  },
+);
+
+export const endCourse = createAsyncThunk(
+  'medicine/endCourse',
+  async ({ courseId, petId, localDate }: { courseId: string; petId: string; localDate?: string }, { rejectWithValue }) => {
+    try {
+      const response = await medicineService.endCourse(courseId, localDate);
+      if (response.status === 1 && response.data) {
+        return { petId, course: response.data };
+      } else {
+        throw new Error(response.message || 'Failed to end course');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to end course';
+      return rejectWithValue({ petId, error: message });
+    }
+  },
+);
+
+export const fetchTodaySchedule = createAsyncThunk(
+  'medicine/fetchTodaySchedule',
+  async ({ petId, localDate }: { petId: string; localDate?: string }, { rejectWithValue }) => {
+    try {
+      const response = await medicineService.getTodaySchedule(petId, localDate);
+      if (response.status === 1 && response.data) {
+        return { petId, data: response.data };
+      } else {
+        throw new Error(response.message || 'Failed to fetch today schedule');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to fetch today schedule';
+      return rejectWithValue({ petId, error: message });
+    }
+  },
+);
+
+export const createLog = createAsyncThunk(
+  'medicine/createLog',
+  async (request: CreateLogRequest, { rejectWithValue }) => {
+    try {
+      const response = await medicineService.createLog(request);
+      if (response.status === 1 && response.data) {
+        return { petId: request.pet_id, log: response.data };
+      } else {
+        throw new Error(response.message || 'Failed to create log');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to create log';
+      return rejectWithValue({ petId: request.pet_id, error: message });
+    }
+  },
+);
+
+export const deleteLog = createAsyncThunk(
+  'medicine/deleteLog',
+  async ({ logId, petId }: { logId: string; petId: string }, { rejectWithValue }) => {
+    try {
+      const response = await medicineService.deleteLog(logId);
+      if (response.status === 1) {
+        return { petId, logId };
+      } else {
+        throw new Error(response.message || 'Failed to delete log');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to delete log';
+      return rejectWithValue({ petId, error: message });
+    }
+  },
+);
+
+const medicineSlice = createSlice({
+  name: 'medicine',
+  initialState,
+  reducers: {
+    clearMedicineState: (state) => {
+      state.medications = {};
+      state.courses = {};
+      state.todaySchedule = {};
+      state.isLoading = {};
+      state.error = {};
+    },
+    clearMedicineError: (state, action) => {
+      const key = action.payload;
+      state.error[key] = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // Fetch medications
+      .addCase(fetchMedications.pending, (state, action) => {
+        const { groupId } = action.meta.arg;
+        state.isLoading[`meds_${groupId}`] = true;
+        state.error[`meds_${groupId}`] = null;
+      })
+      .addCase(fetchMedications.fulfilled, (state, action) => {
+        const { groupId, data } = action.payload;
+        state.isLoading[`meds_${groupId}`] = false;
+        state.medications[groupId] = data;
+      })
+      .addCase(fetchMedications.rejected, (state, action) => {
+        const payload = action.payload as { groupId: string; error: string };
+        state.isLoading[`meds_${payload.groupId}`] = false;
+        state.error[`meds_${payload.groupId}`] = payload.error;
+      })
+      // Create medication
+      .addCase(createMedication.pending, (state, action) => {
+        const { group_id } = action.meta.arg;
+        state.isLoading[`meds_${group_id}`] = true;
+      })
+      .addCase(createMedication.fulfilled, (state, action) => {
+        const { groupId } = action.payload;
+        state.isLoading[`meds_${groupId}`] = false;
+      })
+      .addCase(createMedication.rejected, (state, action) => {
+        const payload = action.payload as { groupId: string; error: string };
+        state.isLoading[`meds_${payload.groupId}`] = false;
+        state.error[`meds_${payload.groupId}`] = payload.error;
+      })
+      // Update medication
+      .addCase(updateMedication.fulfilled, (state, action) => {
+        const { groupId } = action.payload;
+        state.isLoading[`meds_${groupId}`] = false;
+      })
+      .addCase(updateMedication.rejected, (state, action) => {
+        const payload = action.payload as { groupId: string; error: string };
+        state.isLoading[`meds_${payload.groupId}`] = false;
+        state.error[`meds_${payload.groupId}`] = payload.error;
+      })
+      // Delete medication
+      .addCase(deleteMedication.fulfilled, (state, action) => {
+        const { groupId, medicationId } = action.payload;
+        state.isLoading[`meds_${groupId}`] = false;
+        if (state.medications[groupId]) {
+          state.medications[groupId] = state.medications[groupId].filter((m) => m.id !== medicationId);
+        }
+      })
+      .addCase(deleteMedication.rejected, (state, action) => {
+        const payload = action.payload as { groupId: string; error: string };
+        state.isLoading[`meds_${payload.groupId}`] = false;
+        state.error[`meds_${payload.groupId}`] = payload.error;
+      })
+      // Fetch courses
+      .addCase(fetchCourses.pending, (state, action) => {
+        const { petId } = action.meta.arg;
+        state.isLoading[`courses_${petId}`] = true;
+        state.error[`courses_${petId}`] = null;
+      })
+      .addCase(fetchCourses.fulfilled, (state, action) => {
+        const { petId, data } = action.payload;
+        state.isLoading[`courses_${petId}`] = false;
+        state.courses[petId] = data;
+      })
+      .addCase(fetchCourses.rejected, (state, action) => {
+        const payload = action.payload as { petId: string; error: string };
+        state.isLoading[`courses_${payload.petId}`] = false;
+        state.error[`courses_${payload.petId}`] = payload.error;
+      })
+      // Create course
+      .addCase(createCourse.fulfilled, (state, action) => {
+        const { petId } = action.payload;
+        state.isLoading[`courses_${petId}`] = false;
+      })
+      .addCase(createCourse.rejected, (state, action) => {
+        const payload = action.payload as { petId: string; error: string };
+        state.isLoading[`courses_${payload.petId}`] = false;
+        state.error[`courses_${payload.petId}`] = payload.error;
+      })
+      // End course
+      .addCase(endCourse.fulfilled, (state, action) => {
+        const { petId } = action.payload;
+        state.isLoading[`courses_${petId}`] = false;
+      })
+      .addCase(endCourse.rejected, (state, action) => {
+        const payload = action.payload as { petId: string; error: string };
+        state.isLoading[`courses_${payload.petId}`] = false;
+        state.error[`courses_${payload.petId}`] = payload.error;
+      })
+      // Fetch today schedule
+      .addCase(fetchTodaySchedule.pending, (state, action) => {
+        const { petId } = action.meta.arg;
+        state.isLoading[`today_${petId}`] = true;
+        state.error[`today_${petId}`] = null;
+      })
+      .addCase(fetchTodaySchedule.fulfilled, (state, action) => {
+        const { petId, data } = action.payload;
+        state.isLoading[`today_${petId}`] = false;
+        state.todaySchedule[petId] = data;
+      })
+      .addCase(fetchTodaySchedule.rejected, (state, action) => {
+        const payload = action.payload as { petId: string; error: string };
+        state.isLoading[`today_${payload.petId}`] = false;
+        state.error[`today_${payload.petId}`] = payload.error;
+      })
+      // Create log
+      .addCase(createLog.fulfilled, (state, action) => {
+        const { petId } = action.payload;
+        state.isLoading[`today_${petId}`] = false;
+      })
+      .addCase(createLog.rejected, (state, action) => {
+        const payload = action.payload as { petId: string; error: string };
+        state.isLoading[`today_${payload.petId}`] = false;
+        state.error[`today_${payload.petId}`] = payload.error;
+      })
+      // Delete log
+      .addCase(deleteLog.fulfilled, (state, action) => {
+        const { petId } = action.payload;
+        state.isLoading[`today_${petId}`] = false;
+      })
+      .addCase(deleteLog.rejected, (state, action) => {
+        const payload = action.payload as { petId: string; error: string };
+        state.isLoading[`today_${payload.petId}`] = false;
+        state.error[`today_${payload.petId}`] = payload.error;
+      })
+      // Handle logout
+      .addCase(logout, (state) => {
+        state.medications = {};
+        state.courses = {};
+        state.todaySchedule = {};
+        state.isLoading = {};
+        state.error = {};
+      });
+  },
+});
+
+export const { clearMedicineState, clearMedicineError } = medicineSlice.actions;
+export default medicineSlice.reducer;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,6 +7,7 @@ export * from './group';
 export * from './weight';
 export * from './meal';
 export * from './food';
+export * from './medicine';
 
 // Common API Types
 export interface ApiResponse<T> {

--- a/frontend/src/types/medicine.ts
+++ b/frontend/src/types/medicine.ts
@@ -1,0 +1,143 @@
+// ===== Medicine Domain Types =====
+
+export type MedicationType = 'oral' | 'topical' | 'injection' | 'eye_drops' | 'ear_drops' | 'other';
+
+export type DosageUnit = 'tablet' | 'ml' | 'mg' | 'drops' | 'puff' | 'unit' | 'application';
+
+export type TimeOfDay = 'all_day' | 'morning' | 'afternoon' | 'evening';
+
+// ===== Response Types =====
+
+export interface MedicationInfo {
+  id: string;
+  group_id: string;
+  name: string;
+  medication_type: MedicationType;
+  default_dosage?: number | null;
+  dosage_unit: DosageUnit;
+  notes?: string | null;
+  creator_id?: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TreatmentCourseInfo {
+  id: string;
+  pet_id: string;
+  pet_name: string;
+  medication_id: string;
+  medication_name: string;
+  medication_type: MedicationType;
+  group_id: string;
+  dosage: number;
+  dosage_unit: DosageUnit;
+  frequency_days: number;
+  times_per_day: string[];
+  start_date: string;
+  end_date?: string | null;
+  notes?: string | null;
+  created_by?: string | null;
+  created_by_name?: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MedicationLogInfo {
+  id: string;
+  pet_id: string;
+  medication_id: string;
+  medication_name: string;
+  group_id: string;
+  course_id?: string | null;
+  dosage: number;
+  dosage_unit: DosageUnit;
+  time_of_day?: string | null;
+  administered_at: string;
+  administered_by?: string | null;
+  administered_by_name?: string | null;
+  notes?: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ScheduledItem {
+  course_id: string;
+  medication_id: string;
+  medication_name: string;
+  medication_type: MedicationType;
+  dosage: number;
+  dosage_unit: DosageUnit;
+  time_of_day: string;
+  is_done: boolean;
+  log_id?: string | null;
+  administered_by_name?: string | null;
+  administered_at?: string | null;
+}
+
+export interface TodayScheduleResponse {
+  pet_id: string;
+  date: string;
+  scheduled_items: ScheduledItem[];
+  ad_hoc_logs: MedicationLogInfo[];
+  summary: {
+    total_scheduled: number;
+    completed: number;
+    pending: number;
+  };
+}
+
+// ===== Request Types =====
+
+export interface CreateMedicationRequest {
+  group_id: string;
+  name: string;
+  medication_type: MedicationType;
+  default_dosage?: number;
+  dosage_unit: DosageUnit;
+  notes?: string;
+}
+
+export interface UpdateMedicationRequest {
+  name?: string;
+  medication_type?: MedicationType;
+  default_dosage?: number;
+  dosage_unit?: DosageUnit;
+  notes?: string;
+}
+
+export interface CreateCourseRequest {
+  pet_id: string;
+  medication_id: string;
+  group_id: string;
+  dosage: number;
+  dosage_unit: DosageUnit;
+  frequency_days: number;
+  times_per_day: TimeOfDay[];
+  start_date: string;
+  end_date?: string;
+  notes?: string;
+}
+
+export interface UpdateCourseRequest {
+  dosage?: number;
+  dosage_unit?: DosageUnit;
+  frequency_days?: number;
+  times_per_day?: TimeOfDay[];
+  end_date?: string;
+  notes?: string;
+  local_date?: string;
+}
+
+export interface CreateLogRequest {
+  pet_id: string;
+  medication_id: string;
+  group_id: string;
+  course_id?: string;
+  dosage: number;
+  dosage_unit: DosageUnit;
+  time_of_day?: TimeOfDay;
+  notes?: string;
+}


### PR DESCRIPTION
Closes #92

## Summary
- Full medicine domain frontend: types, API service, Redux slice, hook, constants, 4 page components, 3 form/modal components
- Replaced ComingSoon placeholder on `/medicine` route with a fully functional MedicinePage
- Three main sections: Today's Medications checklist (one-tap mark done), Active Treatments list, Medication Database grid
- Viewer role users see read-only view (add/edit/done buttons hidden)

## Files changed by layer
- **Types**: `src/types/medicine.ts` (new — all medicine interfaces), `src/types/index.ts` (re-export)
- **API services**: `src/api/services/MedicineService.ts` (new — 10 endpoints), `src/api/services/index.ts` (re-export)
- **Store / slices**: `src/store/slices/medicineSlice.ts` (new — medications, courses, todaySchedule state + 10 async thunks), `src/store/index.ts` (register + exports)
- **Hooks**: `src/hooks/medicine/useMedicine.ts` (new), `src/hooks/medicine/index.ts` (new), `src/hooks/index.ts` (re-export)
- **Constants**: `src/constants/medicationTypes.ts` (new — type→icon/color mapping, time/dosage labels)
- **Components**: `src/components/medicine/MedicinePage.tsx`, `TodayMedicationChecklist.tsx`, `ActiveCoursesList.tsx`, `MedicationDatabase.tsx`, `index.ts` (all new)
- **Forms**: `src/components/forms/CreateMedicationForm.tsx`, `CreateCourseForm.tsx`, `CourseDetailsModal.tsx` (all new)
- **Routing / config**: `src/App.tsx` (replaced ComingSoon import + route)

## Backend endpoints consumed
- `GET /medicine/today?pet_id=&local_date=` — medicine_router.py:23
- `GET /medicine/list?group_id=` — medicine_router.py:61
- `GET /medicine/{id}` — medicine_router.py:227
- `POST /medicine/create` — medicine_router.py:44
- `POST /medicine/{id}/update` — medicine_router.py:192
- `POST /medicine/{id}/delete` — medicine_router.py:210
- `POST /medicine/course/create` — medicine_router.py:81
- `POST /medicine/course/{id}/end` — medicine_router.py:116
- `GET /medicine/course/list?pet_id=&status=` — medicine_router.py:134
- `POST /medicine/log/create` — medicine_router.py:155
- `POST /medicine/log/{id}/delete` — medicine_router.py:172

## Manual test plan
1. Navigate to /medicine tab — MedicinePage renders (no more ComingSoon)
2. No medications: see empty state for all 3 sections with action prompts
3. Click "+" on Medication Database → fill name/type/dosage → Save → appears in grid
4. Click "+" on Active Treatments → select medication, set frequency/times → Start Treatment
5. Today's Medications shows items → tap checkmark to mark done (turns green)
6. Tap an active treatment card → Course Details modal → End Treatment with confirmation
7. Test at 375px viewport: all sections stack correctly

## Mobile viewport check
- Verified at 375px: single-column layout, all tap targets ≥ 40px
- Notable breakpoints: sm:grid-cols-2 for medication database cards

## Notes
- `canEdit` is determined by looking up the pet's `PetAccess.role` from `userPets` in the pet store (since `selectedPet` is `Pet` type without `user_permission`)
- Medication type icons: Pill (oral), Droplets (topical), Syringe (injection), Eye (eye_drops), Ear (ear_drops) — all from lucide-react
- No LogMedicationForm for ad-hoc logs — deferred to v2 as it wasn't critical for the initial launch