### PR TITLE
[#95-#103] iOS App Migration — full SwiftUI app with all features

### DIFF
--- a/ios/PetCare/PetCare/ContentView.swift
+++ b/ios/PetCare/PetCare/ContentView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var authViewModel = AuthViewModel()
+    @State private var petSelector = PetSelectorViewModel()
+    @State private var isRestoringSession = true
+
+    var body: some View {
+        Group {
+            if isRestoringSession {
+                ZStack {
+                    Color.surface0.ignoresSafeArea()
+                    VStack(spacing: 16) {
+                        Image(systemName: "pawprint.fill")
+                            .font(.system(size: 48))
+                            .foregroundStyle(Color.accentTeal)
+                        ProgressView()
+                            .tint(Color.accentTeal)
+                    }
+                }
+            } else if authViewModel.isLoggedIn {
+                MainTabView(authViewModel: authViewModel, petSelector: petSelector)
+            } else {
+                LoginView(authViewModel: authViewModel)
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: authViewModel.isLoggedIn)
+        .animation(.easeInOut(duration: 0.3), value: isRestoringSession)
+        .task {
+            await authViewModel.restoreSession()
+            if authViewModel.isLoggedIn {
+                await petSelector.loadPets()
+            }
+            isRestoringSession = false
+        }
+        .onChange(of: authViewModel.isLoggedIn) { _, isLoggedIn in
+            if isLoggedIn {
+                Task { await petSelector.loadPets() }
+            } else {
+                petSelector.pets = []
+                petSelector.selectedPet = nil
+                petSelector.selectedPetDetails = nil
+            }
+        }
+    }
+}

--- a/ios/PetCare/PetCare/Models/AuthModels.swift
+++ b/ios/PetCare/PetCare/Models/AuthModels.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+// MARK: - Request
+
+struct GoogleLoginRequest: Codable {
+    let token: String
+}
+
+// MARK: - Response envelope
+
+struct APIResponse<T: Codable>: Codable {
+    let status: Int
+    let data: T?
+    let message: String?
+}
+
+// MARK: - Login response data
+
+struct LoginResponseData: Codable {
+    let accessToken: String
+    let tokenType: String
+    let user: User
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case user
+    }
+}
+
+// MARK: - User (auth context — lightweight)
+
+struct User: Codable, Identifiable {
+    let id: String
+    let email: String
+    let name: String
+    let picture: String?
+}

--- a/ios/PetCare/PetCare/Models/FoodModels.swift
+++ b/ios/PetCare/PetCare/Models/FoodModels.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+struct Food: Codable, Identifiable {
+    let id: String
+    let brand: String?
+    let productName: String?
+    let foodType: String?
+    let targetPet: String?
+    let unitWeightG: Double?
+    let caloriesPer100g: Double?
+    let caloriesPerUnit: Double?
+    let proteinPercentage: Double?
+    let fatPercentage: Double?
+    let moisturePercentage: Double?
+    let carbohydratePercentage: Double?
+    let photoUrl: String?
+    let groupId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, brand
+        case productName = "product_name"
+        case foodType = "food_type"
+        case targetPet = "target_pet"
+        case unitWeightG = "unit_weight_g"
+        case caloriesPer100g = "calories_per_100g"
+        case caloriesPerUnit = "calories_per_unit"
+        case proteinPercentage = "protein_percentage"
+        case fatPercentage = "fat_percentage"
+        case moisturePercentage = "moisture_percentage"
+        case carbohydratePercentage = "carbohydrate_percentage"
+        case photoUrl = "photo_url"
+        case groupId = "group_id"
+    }
+
+    var displayName: String {
+        [brand, productName].compactMap { $0 }.joined(separator: " - ")
+    }
+}
+
+struct CreateFoodRequest: Codable {
+    let brand: String
+    let productName: String
+    let foodType: String?
+    let targetPet: String?
+    let unitWeightG: Double?
+    let caloriesPer100g: Double?
+    let proteinPercentage: Double?
+    let fatPercentage: Double?
+    let moisturePercentage: Double?
+    let carbohydratePercentage: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case brand
+        case productName = "product_name"
+        case foodType = "food_type"
+        case targetPet = "target_pet"
+        case unitWeightG = "unit_weight_g"
+        case caloriesPer100g = "calories_per_100g"
+        case proteinPercentage = "protein_percentage"
+        case fatPercentage = "fat_percentage"
+        case moisturePercentage = "moisture_percentage"
+        case carbohydratePercentage = "carbohydrate_percentage"
+    }
+}
+
+struct UpdateFoodRequest: Codable {
+    var brand: String?
+    var productName: String?
+    var foodType: String?
+    var targetPet: String?
+    var unitWeightG: Double?
+    var caloriesPer100g: Double?
+    var proteinPercentage: Double?
+    var fatPercentage: Double?
+    var moisturePercentage: Double?
+    var carbohydratePercentage: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case brand
+        case productName = "product_name"
+        case foodType = "food_type"
+        case targetPet = "target_pet"
+        case unitWeightG = "unit_weight_g"
+        case caloriesPer100g = "calories_per_100g"
+        case proteinPercentage = "protein_percentage"
+        case fatPercentage = "fat_percentage"
+        case moisturePercentage = "moisture_percentage"
+        case carbohydratePercentage = "carbohydrate_percentage"
+    }
+}

--- a/ios/PetCare/PetCare/Models/GroupModels.swift
+++ b/ios/PetCare/PetCare/Models/GroupModels.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+struct Group: Codable, Identifiable {
+    let id: String
+    let name: String
+    let creatorId: String?
+    let creatorName: String?
+    let role: String?
+    let memberCount: Int?
+    let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, role
+        case creatorId = "creator_id"
+        case creatorName = "creator_name"
+        case memberCount = "member_count"
+        case createdAt = "created_at"
+    }
+}
+
+struct GroupMember: Codable, Identifiable {
+    let id: String
+    let name: String
+    let email: String
+    let role: String
+    let picture: String?
+}
+
+struct GroupPet: Codable, Identifiable {
+    let id: String
+    let name: String
+    let ownerId: String?
+    let ownerName: String?
+    let permissionLevel: String?
+    let photoUrl: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case ownerId = "owner_id"
+        case ownerName = "owner_name"
+        case permissionLevel = "permission_level"
+        case photoUrl = "photo_url"
+    }
+}
+
+struct InvitationPreview: Codable {
+    let groupName: String
+    let inviterName: String
+    let role: String
+    let expirationDate: String?
+    let invitationId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case role
+        case groupName = "group_name"
+        case inviterName = "inviter_name"
+        case expirationDate = "expiration_date"
+        case invitationId = "invitation_id"
+    }
+}
+
+struct InvitationResult: Codable {
+    let inviteCode: String
+    let expirationDate: String?
+
+    enum CodingKeys: String, CodingKey {
+        case inviteCode = "invite_code"
+        case expirationDate = "expiration_date"
+    }
+}
+
+struct CreateGroupRequest: Codable {
+    let name: String
+}
+
+struct CreateInvitationRequest: Codable {
+    let role: String
+}
+
+struct JoinGroupRequest: Codable {
+    let inviteCode: String
+
+    enum CodingKeys: String, CodingKey {
+        case inviteCode = "invite_code"
+    }
+}

--- a/ios/PetCare/PetCare/Models/MealModels.swift
+++ b/ios/PetCare/PetCare/Models/MealModels.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+struct Meal: Codable, Identifiable {
+    let id: String
+    let petId: String?
+    let petName: String?
+    let foodId: String?
+    let foodDetails: MealFoodDetails?
+    let servingType: String?
+    let servingAmount: Double?
+    let actualWeightG: Double?
+    let calories: Double?
+    let recordedBy: String?
+    let fedAt: String?
+    let mealType: String?
+    let notes: String?
+    let groupId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, calories, notes
+        case petId = "pet_id"
+        case petName = "pet_name"
+        case foodId = "food_id"
+        case foodDetails = "food_details"
+        case servingType = "serving_type"
+        case servingAmount = "serving_amount"
+        case actualWeightG = "actual_weight_g"
+        case recordedBy = "recorded_by"
+        case fedAt = "fed_at"
+        case mealType = "meal_type"
+        case groupId = "group_id"
+    }
+}
+
+struct MealFoodDetails: Codable {
+    let brand: String?
+    let productName: String?
+    let foodType: String?
+    let photoUrl: String?
+
+    enum CodingKeys: String, CodingKey {
+        case brand
+        case productName = "product_name"
+        case foodType = "food_type"
+        case photoUrl = "photo_url"
+    }
+}
+
+struct TodaySummary: Codable {
+    let date: String?
+    let petMeals: [Meal]?
+    let totalCalories: Double?
+    let calorieTarget: Int?
+    let targetAchievementPercentage: Double?
+    let mealDistribution: [String: Int]?
+    let feedingTimeline: [[String: String]]?
+
+    enum CodingKeys: String, CodingKey {
+        case date
+        case petMeals = "pet_meals"
+        case totalCalories = "total_calories"
+        case calorieTarget = "calorie_target"
+        case targetAchievementPercentage = "target_achievement_percentage"
+        case mealDistribution = "meal_distribution"
+        case feedingTimeline = "feeding_timeline"
+    }
+}
+
+struct MealSummary: Codable {
+    let totalMeals: Int?
+    let totalCalories: Double?
+    let dailyAverageCalories: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case totalMeals = "total_meals"
+        case totalCalories = "total_calories"
+        case dailyAverageCalories = "daily_average_calories"
+    }
+}
+
+struct CreateMealRequest: Codable {
+    let petId: String
+    let foodId: String
+    let mealType: String?
+    let servingType: String?
+    let servingAmount: Double?
+    let fedAt: String?
+    let notes: String?
+
+    enum CodingKeys: String, CodingKey {
+        case notes
+        case petId = "pet_id"
+        case foodId = "food_id"
+        case mealType = "meal_type"
+        case servingType = "serving_type"
+        case servingAmount = "serving_amount"
+        case fedAt = "fed_at"
+    }
+}
+
+struct UpdateMealRequest: Codable {
+    var foodId: String?
+    var mealType: String?
+    var servingType: String?
+    var servingAmount: Double?
+    var fedAt: String?
+    var notes: String?
+
+    enum CodingKeys: String, CodingKey {
+        case notes
+        case foodId = "food_id"
+        case mealType = "meal_type"
+        case servingType = "serving_type"
+        case servingAmount = "serving_amount"
+        case fedAt = "fed_at"
+    }
+}

--- a/ios/PetCare/PetCare/Models/MedicineModels.swift
+++ b/ios/PetCare/PetCare/Models/MedicineModels.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+struct Medication: Codable, Identifiable {
+    let id: String
+    let name: String
+    let groupId: String?
+    let isActive: Bool?
+    let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case groupId = "group_id"
+        case isActive = "is_active"
+        case createdAt = "created_at"
+    }
+}
+
+struct TreatmentCourse: Codable, Identifiable {
+    let id: String
+    let petId: String?
+    let medicationId: String?
+    let medicationName: String?
+    let dosage: String?
+    let frequencyDays: Int?
+    let startDate: String?
+    let endDate: String?
+    let status: String?
+    let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, dosage, status
+        case petId = "pet_id"
+        case medicationId = "medication_id"
+        case medicationName = "medication_name"
+        case frequencyDays = "frequency_days"
+        case startDate = "start_date"
+        case endDate = "end_date"
+        case createdAt = "created_at"
+    }
+}
+
+struct TodaySchedule: Codable {
+    let petId: String?
+    let date: String?
+    let scheduledCourses: [ScheduledCourseItem]?
+    let completionStatus: CompletionStatus?
+
+    enum CodingKeys: String, CodingKey {
+        case date
+        case petId = "pet_id"
+        case scheduledCourses = "scheduled_courses"
+        case completionStatus = "completion_status"
+    }
+}
+
+struct ScheduledCourseItem: Codable, Identifiable {
+    var id: String { courseId ?? UUID().uuidString }
+    let courseId: String?
+    let medicationName: String?
+    let dosage: String?
+    let timesToday: Int?
+    let completedLogs: [CompletedLog]?
+
+    enum CodingKeys: String, CodingKey {
+        case dosage
+        case courseId = "course_id"
+        case medicationName = "medication_name"
+        case timesToday = "times_today"
+        case completedLogs = "completed_logs"
+    }
+
+    var completedCount: Int { completedLogs?.count ?? 0 }
+    var isFullyDone: Bool { completedCount >= (timesToday ?? 1) }
+}
+
+struct CompletedLog: Codable, Identifiable {
+    var id: String { logId ?? UUID().uuidString }
+    let logId: String?
+    let loggedAt: String?
+    let recordedBy: String?
+    let recordedByName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case logId = "log_id"
+        case loggedAt = "logged_at"
+        case recordedBy = "recorded_by"
+        case recordedByName = "recorded_by_name"
+    }
+}
+
+struct CompletionStatus: Codable {
+    let totalRequired: Int?
+    let totalCompleted: Int?
+    let percentage: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case totalRequired = "total_required"
+        case totalCompleted = "total_completed"
+        case percentage
+    }
+}
+
+struct CreateMedicationRequest: Codable {
+    let name: String
+    let groupId: String
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case groupId = "group_id"
+    }
+}
+
+struct UpdateMedicationRequest: Codable {
+    var name: String?
+}
+
+struct CreateCourseRequest: Codable {
+    let petId: String
+    let medicationId: String
+    let dosage: String?
+    let frequencyDays: Int?
+    let startDate: String?
+    let endDate: String?
+
+    enum CodingKeys: String, CodingKey {
+        case dosage
+        case petId = "pet_id"
+        case medicationId = "medication_id"
+        case frequencyDays = "frequency_days"
+        case startDate = "start_date"
+        case endDate = "end_date"
+    }
+}
+
+struct CreateLogRequest: Codable {
+    let courseId: String
+    let loggedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case courseId = "course_id"
+        case loggedAt = "logged_at"
+    }
+}

--- a/ios/PetCare/PetCare/Models/PetModels.swift
+++ b/ios/PetCare/PetCare/Models/PetModels.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+// MARK: - Enums
+
+enum PetType: String, Codable, CaseIterable {
+    case dog, cat, bird, fish, rabbit, other
+}
+
+enum PetGender: String, Codable, CaseIterable {
+    case male, female, unknown
+}
+
+// MARK: - Pet (from /pets/accessible list items)
+
+struct PetInfo: Codable, Identifiable {
+    let id: String
+    let name: String
+    let petType: PetType
+    let breed: String?
+    let gender: PetGender?
+    let currentWeightKg: Double?
+    let dailyCalorieTarget: Int?
+    let targetWeightKg: Double?
+    let ownerId: String
+    let ownerName: String?
+    let groupId: String?
+    let groupName: String?
+    let createdAt: String?
+    let updatedAt: String?
+    let photoUrl: String?
+    let isActive: Bool?
+    let userPermission: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, breed, gender
+        case petType = "pet_type"
+        case currentWeightKg = "current_weight_kg"
+        case dailyCalorieTarget = "daily_calorie_target"
+        case targetWeightKg = "target_weight_kg"
+        case ownerId = "owner_id"
+        case ownerName = "owner_name"
+        case groupId = "group_id"
+        case groupName = "group_name"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case photoUrl = "photo_url"
+        case isActive = "is_active"
+        case userPermission = "user_permission"
+    }
+}
+
+// MARK: - Pet Details (from /pets/{id}/details)
+
+struct PetDetails: Codable, Identifiable {
+    let id: String
+    let name: String
+    let petType: PetType
+    let breed: String?
+    let gender: PetGender?
+    let birthDate: String?
+    let age: String?
+    let currentWeightKg: Double?
+    let targetWeightKg: Double?
+    let heightCm: Double?
+    let isSpayed: Bool?
+    let microchipId: String?
+    let dailyCalorieTarget: Int?
+    let ownerId: String
+    let ownerName: String?
+    let groupId: String?
+    let groupName: String?
+    let photoUrl: String?
+    let permissionLevel: String?
+    let notes: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, breed, gender, age, notes
+        case petType = "pet_type"
+        case birthDate = "birth_date"
+        case currentWeightKg = "current_weight_kg"
+        case targetWeightKg = "target_weight_kg"
+        case heightCm = "height_cm"
+        case isSpayed = "is_spayed"
+        case microchipId = "microchip_id"
+        case dailyCalorieTarget = "daily_calorie_target"
+        case ownerId = "owner_id"
+        case ownerName = "owner_name"
+        case groupId = "group_id"
+        case groupName = "group_name"
+        case photoUrl = "photo_url"
+        case permissionLevel = "permission_level"
+    }
+}
+
+// MARK: - Requests
+
+struct CreatePetRequest: Codable {
+    let name: String
+    let petType: PetType
+    let breed: String?
+    let gender: PetGender?
+    let birthDate: String?
+    let currentWeightKg: Double?
+    let targetWeightKg: Double?
+    let dailyCalorieTarget: Int?
+    let notes: String?
+
+    enum CodingKeys: String, CodingKey {
+        case name, breed, gender, notes
+        case petType = "pet_type"
+        case birthDate = "birth_date"
+        case currentWeightKg = "current_weight_kg"
+        case targetWeightKg = "target_weight_kg"
+        case dailyCalorieTarget = "daily_calorie_target"
+    }
+}
+
+struct UpdatePetRequest: Codable {
+    var name: String?
+    var breed: String?
+    var gender: PetGender?
+    var birthDate: String?
+    var currentWeightKg: Double?
+    var targetWeightKg: Double?
+    var dailyCalorieTarget: Int?
+    var notes: String?
+
+    enum CodingKeys: String, CodingKey {
+        case name, breed, gender, notes
+        case birthDate = "birth_date"
+        case currentWeightKg = "current_weight_kg"
+        case targetWeightKg = "target_weight_kg"
+        case dailyCalorieTarget = "daily_calorie_target"
+    }
+}
+
+struct AssignPetToGroupRequest: Codable {
+    let groupId: String
+
+    enum CodingKeys: String, CodingKey {
+        case groupId = "group_id"
+    }
+}

--- a/ios/PetCare/PetCare/Models/UserModels.swift
+++ b/ios/PetCare/PetCare/Models/UserModels.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct UserInfo: Codable, Identifiable {
+    let id: String
+    let email: String
+    let name: String
+    let picture: String?
+    let personalGroupId: String?
+    let createdAt: String?
+    let updatedAt: String?
+    let source: String?
+    let isActive: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case id, email, name, picture, source
+        case personalGroupId = "personal_group_id"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case isActive = "is_active"
+    }
+}
+
+struct UpdateUserRequest: Codable {
+    var name: String?
+    var email: String?
+}

--- a/ios/PetCare/PetCare/Models/WeightModels.swift
+++ b/ios/PetCare/PetCare/Models/WeightModels.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+struct WeightRecord: Codable, Identifiable {
+    let id: String
+    let petId: String?
+    let weightKg: Double
+    let timestamp: String?
+    let recordedBy: String?
+    let recordedByName: String?
+    let notes: String?
+    let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, timestamp, notes
+        case petId = "pet_id"
+        case weightKg = "weight_kg"
+        case recordedBy = "recorded_by"
+        case recordedByName = "recorded_by_name"
+        case createdAt = "created_at"
+    }
+}
+
+struct WeightListResponse: Codable {
+    let records: [WeightRecord]
+    let total: Int
+    let page: Int
+    let number: Int
+    let totalPages: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case records, total, page, number
+        case totalPages = "total_pages"
+    }
+}
+
+struct CreateWeightRequest: Codable {
+    let petId: String
+    let weightKg: Double
+    let timestamp: String?
+    let notes: String?
+
+    enum CodingKeys: String, CodingKey {
+        case notes, timestamp
+        case petId = "pet_id"
+        case weightKg = "weight_kg"
+    }
+}
+
+struct UpdateWeightRequest: Codable {
+    var weightKg: Double?
+    var timestamp: String?
+    var notes: String?
+
+    enum CodingKeys: String, CodingKey {
+        case notes, timestamp
+        case weightKg = "weight_kg"
+    }
+}

--- a/ios/PetCare/PetCare/PetCareApp.swift
+++ b/ios/PetCare/PetCare/PetCareApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import GoogleSignIn
+
+@main
+struct PetCareApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .onOpenURL { url in
+                    GIDSignIn.sharedInstance.handle(url)
+                }
+        }
+    }
+}

--- a/ios/PetCare/PetCare/Services/APIClient.swift
+++ b/ios/PetCare/PetCare/Services/APIClient.swift
@@ -1,0 +1,369 @@
+import Foundation
+
+final class APIClient {
+    static let shared = APIClient()
+
+    private let baseURL = "https://petcare-staging.onrender.com"
+    private let session: URLSession
+    private let decoder: JSONDecoder
+
+    /// Posted when a 401 is received — AuthViewModel listens to trigger logout.
+    static let unauthorizedNotification = Notification.Name("APIClient.unauthorized")
+
+    private init() {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        session = URLSession(configuration: config)
+        decoder = JSONDecoder()
+    }
+
+    private var token: String? {
+        UserDefaults.standard.string(forKey: "petcare_token")
+    }
+
+    // MARK: - Auth
+
+    func googleLogin(idToken: String) async throws -> LoginResponseData {
+        let body = GoogleLoginRequest(token: idToken)
+        let response: APIResponse<LoginResponseData> = try await post(path: "/auth/google/login", body: body, authenticated: false)
+        return try unwrap(response)
+    }
+
+    func fetchCurrentUser() async throws -> UserInfo {
+        let response: APIResponse<UserInfo> = try await get(path: "/user/me")
+        return try unwrap(response)
+    }
+
+    func updateUser(_ request: UpdateUserRequest) async throws -> UserInfo {
+        let response: APIResponse<UserInfo> = try await post(path: "/user/update", body: request)
+        return try unwrap(response)
+    }
+
+    func uploadUserPhoto(data: Data, filename: String) async throws -> PhotoUploadResult {
+        let response: APIResponse<PhotoUploadResult> = try await uploadFile(path: "/user/photo/upload", fileData: data, filename: filename)
+        return try unwrap(response)
+    }
+
+    // MARK: - Pets
+
+    func fetchAccessiblePets() async throws -> [PetInfo] {
+        let response: APIResponse<[PetInfo]> = try await get(path: "/pets/accessible")
+        return try unwrap(response)
+    }
+
+    func fetchPetDetails(petId: String) async throws -> PetDetails {
+        let response: APIResponse<PetDetails> = try await get(path: "/pets/\(petId)/details")
+        return try unwrap(response)
+    }
+
+    func createPet(_ request: CreatePetRequest) async throws -> PetInfo {
+        let response: APIResponse<PetInfo> = try await post(path: "/pets/create", body: request)
+        return try unwrap(response)
+    }
+
+    func updatePet(petId: String, _ request: UpdatePetRequest) async throws -> PetInfo {
+        let response: APIResponse<PetInfo> = try await post(path: "/pets/\(petId)/update", body: request)
+        return try unwrap(response)
+    }
+
+    func uploadPetPhoto(petId: String, data: Data, filename: String) async throws -> PhotoUploadResult {
+        let response: APIResponse<PhotoUploadResult> = try await uploadFile(path: "/pets/\(petId)/photo/upload", fileData: data, filename: filename)
+        return try unwrap(response)
+    }
+
+    func assignPetToGroup(petId: String, groupId: String) async throws {
+        let body = AssignPetToGroupRequest(groupId: groupId)
+        let _: APIResponse<AnyCodable> = try await post(path: "/pets/\(petId)/assign_group", body: body)
+    }
+
+    // MARK: - Groups
+
+    func fetchMyGroups() async throws -> [Group] {
+        let response: APIResponse<[Group]> = try await get(path: "/groups/my_groups")
+        return try unwrap(response)
+    }
+
+    func fetchGroupMembers(groupId: String) async throws -> [GroupMember] {
+        let response: APIResponse<[GroupMember]> = try await get(path: "/groups/\(groupId)/members")
+        return try unwrap(response)
+    }
+
+    func fetchGroupPets(groupId: String) async throws -> [GroupPet] {
+        let response: APIResponse<[GroupPet]> = try await get(path: "/groups/\(groupId)/pets")
+        return try unwrap(response)
+    }
+
+    func createGroup(_ request: CreateGroupRequest) async throws -> Group {
+        let response: APIResponse<Group> = try await post(path: "/groups/create", body: request)
+        return try unwrap(response)
+    }
+
+    func deleteGroup(groupId: String) async throws {
+        let _: APIResponse<AnyCodable> = try await post(path: "/groups/delete/\(groupId)", body: EmptyBody())
+    }
+
+    func createInvitation(groupId: String, role: String) async throws -> InvitationResult {
+        let body = CreateInvitationRequest(role: role)
+        let response: APIResponse<InvitationResult> = try await post(path: "/groups/\(groupId)/invite", body: body)
+        return try unwrap(response)
+    }
+
+    func previewInvitation(inviteCode: String) async throws -> InvitationPreview {
+        let response: APIResponse<InvitationPreview> = try await get(path: "/groups/invitation/\(inviteCode)")
+        return try unwrap(response)
+    }
+
+    func joinGroup(inviteCode: String) async throws -> Group {
+        let body = JoinGroupRequest(inviteCode: inviteCode)
+        let response: APIResponse<Group> = try await post(path: "/groups/join", body: body)
+        return try unwrap(response)
+    }
+
+    // MARK: - Foods
+
+    func fetchFoods(groupId: String) async throws -> [Food] {
+        let response: APIResponse<[Food]> = try await get(path: "/foods/info?group_id=\(groupId)")
+        return try unwrap(response)
+    }
+
+    func fetchFoodDetails(foodId: String) async throws -> Food {
+        let response: APIResponse<Food> = try await get(path: "/foods/\(foodId)/details")
+        return try unwrap(response)
+    }
+
+    func createFood(groupId: String, _ request: CreateFoodRequest) async throws -> Food {
+        let response: APIResponse<Food> = try await post(path: "/foods/create?group_id=\(groupId)", body: request)
+        return try unwrap(response)
+    }
+
+    func updateFood(foodId: String, _ request: UpdateFoodRequest) async throws -> Food {
+        let response: APIResponse<Food> = try await post(path: "/foods/\(foodId)/update", body: request)
+        return try unwrap(response)
+    }
+
+    func deleteFood(foodId: String) async throws {
+        let _: APIResponse<AnyCodable> = try await post(path: "/foods/\(foodId)/delete", body: EmptyBody())
+    }
+
+    func uploadFoodPhoto(foodId: String, data: Data, filename: String) async throws -> PhotoUploadResult {
+        let response: APIResponse<PhotoUploadResult> = try await uploadFile(path: "/foods/\(foodId)/photo/upload", fileData: data, filename: filename)
+        return try unwrap(response)
+    }
+
+    // MARK: - Meals
+
+    func fetchMeals(petId: String, dateFrom: String? = nil, dateTo: String? = nil, limit: Int = 50) async throws -> [Meal] {
+        var path = "/meals?pet_id=\(petId)&limit=\(limit)"
+        if let df = dateFrom { path += "&date_from=\(df)" }
+        if let dt = dateTo { path += "&date_to=\(dt)" }
+        let response: APIResponse<[Meal]> = try await get(path: path)
+        return try unwrap(response)
+    }
+
+    func fetchMealDetails(mealId: String) async throws -> Meal {
+        let response: APIResponse<Meal> = try await get(path: "/meals/\(mealId)/details")
+        return try unwrap(response)
+    }
+
+    func fetchTodaySummary(petId: String, localDate: String? = nil) async throws -> TodaySummary {
+        var path = "/meals/today?pet_id=\(petId)"
+        if let ld = localDate { path += "&local_date=\(ld)" }
+        let response: APIResponse<TodaySummary> = try await get(path: path)
+        return try unwrap(response)
+    }
+
+    func fetchMealSummary(petId: String, dateFrom: String, dateTo: String) async throws -> MealSummary {
+        let path = "/meals/summary?pet_id=\(petId)&date_from=\(dateFrom)&date_to=\(dateTo)"
+        let response: APIResponse<MealSummary> = try await get(path: path)
+        return try unwrap(response)
+    }
+
+    func createMeal(_ request: CreateMealRequest) async throws -> Meal {
+        let response: APIResponse<Meal> = try await post(path: "/meals", body: request)
+        return try unwrap(response)
+    }
+
+    func updateMeal(mealId: String, _ request: UpdateMealRequest) async throws -> Meal {
+        let response: APIResponse<Meal> = try await post(path: "/meals/\(mealId)/update", body: request)
+        return try unwrap(response)
+    }
+
+    func deleteMeal(mealId: String) async throws {
+        let _: APIResponse<AnyCodable> = try await post(path: "/meals/\(mealId)/delete", body: EmptyBody())
+    }
+
+    // MARK: - Weights
+
+    func fetchWeights(petId: String, start: String? = nil, end: String? = nil, page: Int = 1, number: Int = 50) async throws -> WeightListResponse {
+        var path = "/weights/info?pet_id=\(petId)&page=\(page)&number=\(number)&order_by=timestamp&order_direction=desc"
+        if let s = start { path += "&start=\(s)" }
+        if let e = end { path += "&end=\(e)" }
+        let response: APIResponse<WeightListResponse> = try await get(path: path)
+        return try unwrap(response)
+    }
+
+    func createWeight(_ request: CreateWeightRequest) async throws -> WeightRecord {
+        let response: APIResponse<WeightRecord> = try await post(path: "/weights/create", body: request)
+        return try unwrap(response)
+    }
+
+    func updateWeight(weightId: String, _ request: UpdateWeightRequest) async throws -> WeightRecord {
+        let response: APIResponse<WeightRecord> = try await post(path: "/weights/update/\(weightId)", body: request)
+        return try unwrap(response)
+    }
+
+    func deleteWeight(weightId: String) async throws {
+        let _: APIResponse<AnyCodable> = try await post(path: "/weights/delete/\(weightId)", body: EmptyBody())
+    }
+
+    // MARK: - Medicine
+
+    func fetchMedications(groupId: String) async throws -> [Medication] {
+        let response: APIResponse<[Medication]> = try await get(path: "/medicine/list?group_id=\(groupId)")
+        return try unwrap(response)
+    }
+
+    func fetchMedicationDetails(medicationId: String) async throws -> Medication {
+        let response: APIResponse<Medication> = try await get(path: "/medicine/\(medicationId)")
+        return try unwrap(response)
+    }
+
+    func createMedication(_ request: CreateMedicationRequest) async throws -> Medication {
+        let response: APIResponse<Medication> = try await post(path: "/medicine/create", body: request)
+        return try unwrap(response)
+    }
+
+    func updateMedication(medicationId: String, _ request: UpdateMedicationRequest) async throws -> Medication {
+        let response: APIResponse<Medication> = try await post(path: "/medicine/\(medicationId)/update", body: request)
+        return try unwrap(response)
+    }
+
+    func deleteMedication(medicationId: String) async throws {
+        let _: APIResponse<AnyCodable> = try await post(path: "/medicine/\(medicationId)/delete", body: EmptyBody())
+    }
+
+    func fetchCourses(petId: String, status: String = "active") async throws -> [TreatmentCourse] {
+        let response: APIResponse<[TreatmentCourse]> = try await get(path: "/medicine/course/list?pet_id=\(petId)&status=\(status)")
+        return try unwrap(response)
+    }
+
+    func createCourse(_ request: CreateCourseRequest) async throws -> TreatmentCourse {
+        let response: APIResponse<TreatmentCourse> = try await post(path: "/medicine/course/create", body: request)
+        return try unwrap(response)
+    }
+
+    func endCourse(courseId: String) async throws {
+        let _: APIResponse<AnyCodable> = try await post(path: "/medicine/course/\(courseId)/end", body: EmptyBody())
+    }
+
+    func fetchTodaySchedule(petId: String, localDate: String? = nil) async throws -> TodaySchedule {
+        var path = "/medicine/today?pet_id=\(petId)"
+        if let ld = localDate { path += "&local_date=\(ld)" }
+        let response: APIResponse<TodaySchedule> = try await get(path: path)
+        return try unwrap(response)
+    }
+
+    func markMedicineDone(_ request: CreateLogRequest) async throws {
+        let _: APIResponse<AnyCodable> = try await post(path: "/medicine/log/create", body: request)
+    }
+
+    func undoMedicineDone(logId: String) async throws {
+        let _: APIResponse<AnyCodable> = try await post(path: "/medicine/log/\(logId)/delete", body: EmptyBody())
+    }
+
+    // MARK: - Generic HTTP helpers
+
+    private func get<Response: Codable>(path: String, authenticated: Bool = true) async throws -> APIResponse<Response> {
+        guard let url = URL(string: baseURL + path) else { throw APIError.invalidURL }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        if authenticated, let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
+        return try await execute(request)
+    }
+
+    private func post<Body: Encodable, Response: Codable>(path: String, body: Body, authenticated: Bool = true) async throws -> APIResponse<Response> {
+        guard let url = URL(string: baseURL + path) else { throw APIError.invalidURL }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if authenticated, let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
+        request.httpBody = try JSONEncoder().encode(body)
+        return try await execute(request)
+    }
+
+    private func uploadFile<Response: Codable>(path: String, fileData: Data, filename: String, authenticated: Bool = true) async throws -> APIResponse<Response> {
+        guard let url = URL(string: baseURL + path) else { throw APIError.invalidURL }
+        let boundary = UUID().uuidString
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        if authenticated, let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }
+
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)!)
+        body.append(fileData)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+        return try await execute(request)
+    }
+
+    private func execute<Response: Codable>(_ request: URLRequest) async throws -> APIResponse<Response> {
+        let (data, httpResponse) = try await session.data(for: request)
+        guard let http = httpResponse as? HTTPURLResponse else { throw APIError.invalidResponse }
+
+        if http.statusCode == 401 {
+            await MainActor.run { NotificationCenter.default.post(name: Self.unauthorizedNotification, object: nil) }
+            throw APIError.unauthorized
+        }
+
+        guard (200...299).contains(http.statusCode) else {
+            let message = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw APIError.httpError(statusCode: http.statusCode, message: message)
+        }
+
+        return try decoder.decode(APIResponse<Response>.self, from: data)
+    }
+
+    private func unwrap<T>(_ response: APIResponse<T>) throws -> T {
+        guard response.status == 1, let data = response.data else {
+            throw APIError.serverError(response.message ?? "Request failed")
+        }
+        return data
+    }
+}
+
+// MARK: - Shared types
+
+struct EmptyBody: Codable {}
+
+struct AnyCodable: Codable {}
+
+struct PhotoUploadResult: Codable {
+    let photoUrl: String?
+
+    enum CodingKeys: String, CodingKey {
+        case photoUrl = "photo_url"
+    }
+}
+
+// MARK: - Errors
+
+enum APIError: LocalizedError {
+    case invalidURL
+    case invalidResponse
+    case unauthorized
+    case httpError(statusCode: Int, message: String)
+    case serverError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "Invalid URL"
+        case .invalidResponse: return "Invalid response from server"
+        case .unauthorized: return "Session expired. Please login again."
+        case .httpError(let code, let message): return "HTTP \(code): \(message)"
+        case .serverError(let message): return message
+        }
+    }
+}

--- a/ios/PetCare/PetCare/Theme/Colors.swift
+++ b/ios/PetCare/PetCare/Theme/Colors.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+// MARK: - Design tokens matching frontend/src/styles/tokens.css
+
+extension Color {
+    // MARK: Surfaces (background layers, deepest → highest)
+    static let surface0 = Color(red: 14/255, green: 18/255, blue: 24/255)
+    static let surface1 = Color(red: 26/255, green: 31/255, blue: 43/255)
+    static let surface2 = Color(red: 36/255, green: 41/255, blue: 56/255)
+    static let surface3 = Color(red: 46/255, green: 52/255, blue: 74/255)
+
+    // MARK: Borders
+    static let borderSubtle = Color(red: 38/255, green: 44/255, blue: 57/255)
+    static let borderDefault = Color(red: 51/255, green: 57/255, blue: 73/255)
+    static let borderStrong = Color(red: 74/255, green: 80/255, blue: 102/255)
+
+    // MARK: Text
+    static let textPrimary = Color(red: 245/255, green: 247/255, blue: 250/255)
+    static let textSecondary = Color(red: 142/255, green: 148/255, blue: 166/255)
+    static let textTertiary = Color(red: 93/255, green: 99/255, blue: 120/255)
+    static let textDisabled = Color(red: 61/255, green: 66/255, blue: 84/255)
+
+    // MARK: Accents
+    static let accentPink = Color(red: 255/255, green: 45/255, blue: 135/255)
+    static let accentPinkHover = Color(red: 255/255, green: 75/255, blue: 155/255)
+    static let accentTeal = Color(red: 16/255, green: 217/255, blue: 176/255)
+    static let accentTealHover = Color(red: 36/255, green: 237/255, blue: 196/255)
+    static let accentPurple = Color(red: 168/255, green: 85/255, blue: 247/255)
+    static let accentPurpleHover = Color(red: 188/255, green: 105/255, blue: 255/255)
+    static let accentBlue = Color(red: 59/255, green: 130/255, blue: 246/255)
+    static let accentBlueHover = Color(red: 79/255, green: 150/255, blue: 255/255)
+
+    // MARK: Chart series (muted palette for data-viz)
+    static let chartPink = Color(red: 196/255, green: 110/255, blue: 142/255)
+    static let chartTeal = Color(red: 78/255, green: 172/255, blue: 152/255)
+    static let chartPurple = Color(red: 148/255, green: 118/255, blue: 198/255)
+    static let chartBlue = Color(red: 96/255, green: 138/255, blue: 196/255)
+    static let chartGray = Color(red: 100/255, green: 106/255, blue: 130/255)
+
+    // MARK: Semantic
+    static let success = accentTeal
+    static let info = accentBlue
+    static let warning = Color(red: 245/255, green: 158/255, blue: 11/255)
+    static let danger = Color(red: 239/255, green: 68/255, blue: 68/255)
+}

--- a/ios/PetCare/PetCare/ViewModels/AuthViewModel.swift
+++ b/ios/PetCare/PetCare/ViewModels/AuthViewModel.swift
@@ -1,0 +1,78 @@
+import Foundation
+import GoogleSignIn
+
+@Observable
+final class AuthViewModel {
+    var user: User?
+    var accessToken: String?
+    var isLoading = false
+    var errorMessage: String?
+    private var unauthorizedObserver: Any?
+
+    var isLoggedIn: Bool { accessToken != nil && user != nil }
+
+    init() {
+        // Listen for 401 notifications from APIClient
+        unauthorizedObserver = NotificationCenter.default.addObserver(
+            forName: APIClient.unauthorizedNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.logout()
+        }
+    }
+
+    deinit {
+        if let observer = unauthorizedObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    /// Try to restore session from persisted token on app launch
+    @MainActor
+    func restoreSession() async {
+        guard let savedToken = UserDefaults.standard.string(forKey: "petcare_token") else { return }
+        self.accessToken = savedToken
+        do {
+            let userInfo = try await APIClient.shared.fetchCurrentUser()
+            self.user = User(id: userInfo.id, email: userInfo.email, name: userInfo.name, picture: userInfo.picture)
+        } catch {
+            // Token is invalid — clear it
+            self.accessToken = nil
+            UserDefaults.standard.removeObject(forKey: "petcare_token")
+        }
+    }
+
+    @MainActor
+    func signInWithGoogle() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                  let rootVC = windowScene.windows.first?.rootViewController else {
+                errorMessage = "Cannot find root view controller"
+                isLoading = false
+                return
+            }
+            let result = try await GIDSignIn.sharedInstance.signIn(withPresenting: rootVC)
+            guard let idToken = result.user.idToken?.tokenString else {
+                errorMessage = "No ID token received from Google"
+                isLoading = false
+                return
+            }
+            let loginData = try await APIClient.shared.googleLogin(idToken: idToken)
+            self.accessToken = loginData.accessToken
+            self.user = loginData.user
+            UserDefaults.standard.set(loginData.accessToken, forKey: "petcare_token")
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    @MainActor
+    func logout() {
+        GIDSignIn.sharedInstance.signOut()
+        accessToken = nil
+        user = nil
+        UserDefaults.standard.removeObject(forKey: "petcare_token")
+    }
+}

--- a/ios/PetCare/PetCare/ViewModels/FoodViewModel.swift
+++ b/ios/PetCare/PetCare/ViewModels/FoodViewModel.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+@Observable
+final class FoodViewModel {
+    var foods: [Food] = []
+    var selectedFood: Food?
+    var isLoading = false
+    var errorMessage: String?
+
+    @MainActor
+    func loadFoods(groupId: String) async {
+        isLoading = true
+        do {
+            foods = try await APIClient.shared.fetchFoods(groupId: groupId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    @MainActor
+    func loadFoodDetails(foodId: String) async {
+        do {
+            selectedFood = try await APIClient.shared.fetchFoodDetails(foodId: foodId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    func createFood(groupId: String, _ request: CreateFoodRequest) async throws -> Food {
+        let food = try await APIClient.shared.createFood(groupId: groupId, request)
+        await loadFoods(groupId: groupId)
+        return food
+    }
+
+    @MainActor
+    func updateFood(foodId: String, _ request: UpdateFoodRequest, groupId: String) async throws {
+        _ = try await APIClient.shared.updateFood(foodId: foodId, request)
+        await loadFoods(groupId: groupId)
+    }
+
+    @MainActor
+    func deleteFood(foodId: String, groupId: String) async throws {
+        try await APIClient.shared.deleteFood(foodId: foodId)
+        await loadFoods(groupId: groupId)
+    }
+}

--- a/ios/PetCare/PetCare/ViewModels/GroupViewModel.swift
+++ b/ios/PetCare/PetCare/ViewModels/GroupViewModel.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+@Observable
+final class GroupViewModel {
+    var groups: [Group] = []
+    var members: [String: [GroupMember]] = [:]
+    var groupPets: [String: [GroupPet]] = [:]
+    var isLoading = false
+    var errorMessage: String?
+
+    @MainActor
+    func loadGroups() async {
+        isLoading = true
+        do {
+            groups = try await APIClient.shared.fetchMyGroups()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    @MainActor
+    func loadMembers(groupId: String) async {
+        do {
+            members[groupId] = try await APIClient.shared.fetchGroupMembers(groupId: groupId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    func loadGroupPets(groupId: String) async {
+        do {
+            groupPets[groupId] = try await APIClient.shared.fetchGroupPets(groupId: groupId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    func createGroup(name: String) async throws -> Group {
+        let group = try await APIClient.shared.createGroup(CreateGroupRequest(name: name))
+        await loadGroups()
+        return group
+    }
+
+    @MainActor
+    func deleteGroup(groupId: String) async throws {
+        try await APIClient.shared.deleteGroup(groupId: groupId)
+        await loadGroups()
+    }
+
+    @MainActor
+    func createInvitation(groupId: String, role: String) async throws -> InvitationResult {
+        return try await APIClient.shared.createInvitation(groupId: groupId, role: role)
+    }
+
+    @MainActor
+    func previewInvitation(inviteCode: String) async throws -> InvitationPreview {
+        return try await APIClient.shared.previewInvitation(inviteCode: inviteCode)
+    }
+
+    @MainActor
+    func joinGroup(inviteCode: String) async throws {
+        _ = try await APIClient.shared.joinGroup(inviteCode: inviteCode)
+        await loadGroups()
+    }
+}

--- a/ios/PetCare/PetCare/ViewModels/MealViewModel.swift
+++ b/ios/PetCare/PetCare/ViewModels/MealViewModel.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+@Observable
+final class MealViewModel {
+    var meals: [Meal] = []
+    var todaySummary: TodaySummary?
+    var isLoading = false
+    var errorMessage: String?
+    var dateFrom: String?
+    var dateTo: String?
+
+    @MainActor
+    func loadMeals(petId: String) async {
+        isLoading = true
+        do {
+            meals = try await APIClient.shared.fetchMeals(petId: petId, dateFrom: dateFrom, dateTo: dateTo)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    @MainActor
+    func loadTodaySummary(petId: String) async {
+        do {
+            todaySummary = try await APIClient.shared.fetchTodaySummary(petId: petId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    func createMeal(_ request: CreateMealRequest) async throws {
+        _ = try await APIClient.shared.createMeal(request)
+    }
+
+    @MainActor
+    func updateMeal(mealId: String, _ request: UpdateMealRequest) async throws {
+        _ = try await APIClient.shared.updateMeal(mealId: mealId, request)
+    }
+
+    @MainActor
+    func deleteMeal(mealId: String) async throws {
+        try await APIClient.shared.deleteMeal(mealId: mealId)
+    }
+
+    @MainActor
+    func refresh(petId: String) async {
+        await loadMeals(petId: petId)
+        await loadTodaySummary(petId: petId)
+    }
+}

--- a/ios/PetCare/PetCare/ViewModels/MedicineViewModel.swift
+++ b/ios/PetCare/PetCare/ViewModels/MedicineViewModel.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+@Observable
+final class MedicineViewModel {
+    var medications: [Medication] = []
+    var courses: [TreatmentCourse] = []
+    var todaySchedule: TodaySchedule?
+    var isLoading = false
+    var errorMessage: String?
+
+    @MainActor
+    func loadMedications(groupId: String) async {
+        do {
+            medications = try await APIClient.shared.fetchMedications(groupId: groupId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    func loadCourses(petId: String) async {
+        do {
+            courses = try await APIClient.shared.fetchCourses(petId: petId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    func loadTodaySchedule(petId: String) async {
+        do {
+            todaySchedule = try await APIClient.shared.fetchTodaySchedule(petId: petId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    func createMedication(name: String, groupId: String) async throws {
+        _ = try await APIClient.shared.createMedication(CreateMedicationRequest(name: name, groupId: groupId))
+        await loadMedications(groupId: groupId)
+    }
+
+    @MainActor
+    func updateMedication(medicationId: String, name: String, groupId: String) async throws {
+        _ = try await APIClient.shared.updateMedication(medicationId: medicationId, UpdateMedicationRequest(name: name))
+        await loadMedications(groupId: groupId)
+    }
+
+    @MainActor
+    func deleteMedication(medicationId: String, groupId: String) async throws {
+        try await APIClient.shared.deleteMedication(medicationId: medicationId)
+        await loadMedications(groupId: groupId)
+    }
+
+    @MainActor
+    func createCourse(_ request: CreateCourseRequest, petId: String) async throws {
+        _ = try await APIClient.shared.createCourse(request)
+        await loadCourses(petId: petId)
+        await loadTodaySchedule(petId: petId)
+    }
+
+    @MainActor
+    func endCourse(courseId: String, petId: String) async throws {
+        try await APIClient.shared.endCourse(courseId: courseId)
+        await loadCourses(petId: petId)
+        await loadTodaySchedule(petId: petId)
+    }
+
+    @MainActor
+    func markDone(courseId: String, petId: String) async throws {
+        let request = CreateLogRequest(courseId: courseId, loggedAt: nil)
+        try await APIClient.shared.markMedicineDone(request)
+        await loadTodaySchedule(petId: petId)
+    }
+
+    @MainActor
+    func undoDone(logId: String, petId: String) async throws {
+        try await APIClient.shared.undoMedicineDone(logId: logId)
+        await loadTodaySchedule(petId: petId)
+    }
+
+    @MainActor
+    func refresh(petId: String, groupId: String) async {
+        isLoading = true
+        await loadMedications(groupId: groupId)
+        await loadCourses(petId: petId)
+        await loadTodaySchedule(petId: petId)
+        isLoading = false
+    }
+}

--- a/ios/PetCare/PetCare/ViewModels/PetSelectorViewModel.swift
+++ b/ios/PetCare/PetCare/ViewModels/PetSelectorViewModel.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+@Observable
+final class PetSelectorViewModel {
+    var pets: [PetInfo] = []
+    var selectedPet: PetInfo?
+    var selectedPetDetails: PetDetails?
+    var isLoading = false
+
+    @MainActor
+    func loadPets() async {
+        isLoading = true
+        do {
+            pets = try await APIClient.shared.fetchAccessiblePets()
+            if selectedPet == nil, let first = pets.first {
+                selectPet(first)
+            }
+        } catch {
+            #if DEBUG
+            print("Failed to load pets: \(error)")
+            #endif
+        }
+        isLoading = false
+    }
+
+    @MainActor
+    func selectPet(_ pet: PetInfo) {
+        selectedPet = pet
+        Task { await loadPetDetails(petId: pet.id) }
+    }
+
+    @MainActor
+    func loadPetDetails(petId: String) async {
+        do {
+            selectedPetDetails = try await APIClient.shared.fetchPetDetails(petId: petId)
+        } catch {
+            #if DEBUG
+            print("Failed to load pet details: \(error)")
+            #endif
+        }
+    }
+
+    @MainActor
+    func refresh() async {
+        await loadPets()
+        if let pet = selectedPet {
+            await loadPetDetails(petId: pet.id)
+        }
+    }
+}

--- a/ios/PetCare/PetCare/ViewModels/PetViewModel.swift
+++ b/ios/PetCare/PetCare/ViewModels/PetViewModel.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+@Observable
+final class PetViewModel {
+    var isLoading = false
+    var errorMessage: String?
+
+    @MainActor
+    func createPet(_ request: CreatePetRequest) async throws -> PetInfo {
+        isLoading = true
+        defer { isLoading = false }
+        errorMessage = nil
+        do {
+            let pet = try await APIClient.shared.createPet(request)
+            return pet
+        } catch {
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
+
+    @MainActor
+    func updatePet(petId: String, _ request: UpdatePetRequest) async throws -> PetInfo {
+        isLoading = true
+        defer { isLoading = false }
+        errorMessage = nil
+        do {
+            let pet = try await APIClient.shared.updatePet(petId: petId, request)
+            return pet
+        } catch {
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
+
+    @MainActor
+    func uploadPhoto(petId: String, imageData: Data) async throws {
+        _ = try await APIClient.shared.uploadPetPhoto(petId: petId, data: imageData, filename: "pet_photo.jpg")
+    }
+
+    @MainActor
+    func assignToGroup(petId: String, groupId: String) async throws {
+        try await APIClient.shared.assignPetToGroup(petId: petId, groupId: groupId)
+    }
+}

--- a/ios/PetCare/PetCare/ViewModels/WeightViewModel.swift
+++ b/ios/PetCare/PetCare/ViewModels/WeightViewModel.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+@Observable
+final class WeightViewModel {
+    var records: [WeightRecord] = []
+    var totalRecords = 0
+    var isLoading = false
+    var errorMessage: String?
+    var dateFrom: String?
+    var dateTo: String?
+
+    var averageWeight: Double? {
+        guard !records.isEmpty else { return nil }
+        return records.map(\.weightKg).reduce(0, +) / Double(records.count)
+    }
+
+    var weightChange: Double? {
+        guard records.count >= 2, let first = records.last, let last = records.first else { return nil }
+        return last.weightKg - first.weightKg
+    }
+
+    @MainActor
+    func loadRecords(petId: String) async {
+        isLoading = true
+        do {
+            let response = try await APIClient.shared.fetchWeights(petId: petId, start: dateFrom, end: dateTo, number: 200)
+            records = response.records
+            totalRecords = response.total
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    @MainActor
+    func createWeight(_ request: CreateWeightRequest) async throws {
+        _ = try await APIClient.shared.createWeight(request)
+    }
+
+    @MainActor
+    func updateWeight(weightId: String, _ request: UpdateWeightRequest) async throws {
+        _ = try await APIClient.shared.updateWeight(weightId: weightId, request)
+    }
+
+    @MainActor
+    func deleteWeight(weightId: String) async throws {
+        try await APIClient.shared.deleteWeight(weightId: weightId)
+    }
+}

--- a/ios/PetCare/PetCare/Views/Dashboard/DashboardPageView.swift
+++ b/ios/PetCare/PetCare/Views/Dashboard/DashboardPageView.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+struct DashboardPageView: View {
+    var petSelector: PetSelectorViewModel
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: 16) {
+                        HeaderView(title: "Dashboard", petSelector: petSelector) {
+                            await petSelector.refresh()
+                        }
+
+                        if let pet = petSelector.selectedPet {
+                            PetSummaryCard(pet: pet, details: petSelector.selectedPetDetails)
+                            QuickStatsGrid(details: petSelector.selectedPetDetails)
+                        } else {
+                            emptyState
+                        }
+                    }
+                }
+            }
+            .navigationBarHidden(true)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "pawprint.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(Color.textTertiary)
+            Text("No pets yet")
+                .font(.headline)
+                .foregroundStyle(Color.textSecondary)
+            Text("Add a pet in Settings to get started")
+                .font(.subheadline)
+                .foregroundStyle(Color.textTertiary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 80)
+    }
+}
+
+struct PetSummaryCard: View {
+    let pet: PetInfo
+    let details: PetDetails?
+
+    var body: some View {
+        HStack(spacing: 16) {
+            if let url = pet.photoUrl, let imageURL = URL(string: url) {
+                AsyncImage(url: imageURL) { image in
+                    image.resizable().scaledToFill()
+                } placeholder: {
+                    ProgressView().tint(Color.accentTeal)
+                }
+                .frame(width: 72, height: 72)
+                .clipShape(Circle())
+            } else {
+                Image(systemName: "pawprint.circle.fill")
+                    .font(.system(size: 60))
+                    .foregroundStyle(Color.accentTeal)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(pet.name)
+                    .font(.title3).fontWeight(.bold)
+                    .foregroundStyle(Color.textPrimary)
+                if let breed = pet.breed {
+                    Text(breed)
+                        .font(.subheadline)
+                        .foregroundStyle(Color.textSecondary)
+                }
+                HStack(spacing: 8) {
+                    if let gender = pet.gender {
+                        Label(gender.rawValue.capitalized, systemImage: gender == .male ? "circle.fill" : "circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(Color.accentBlue)
+                    }
+                    Text(pet.petType.rawValue.capitalized)
+                        .font(.caption)
+                        .foregroundStyle(Color.textTertiary)
+                }
+            }
+            Spacer()
+        }
+        .padding()
+        .background(Color.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal)
+    }
+}
+
+struct QuickStatsGrid: View {
+    let details: PetDetails?
+
+    var body: some View {
+        HStack(spacing: 12) {
+            StatCard(title: "Weight", value: details?.currentWeightKg.map { String(format: "%.1f kg", $0) } ?? "—", icon: "scalemass.fill", color: .accentTeal)
+            StatCard(title: "Target", value: details?.targetWeightKg.map { String(format: "%.1f kg", $0) } ?? "—", icon: "target", color: .accentPurple)
+            StatCard(title: "Cal/Day", value: details?.dailyCalorieTarget.map { "\($0)" } ?? "—", icon: "flame.fill", color: .accentPink)
+        }
+        .padding(.horizontal)
+    }
+}
+
+struct StatCard: View {
+    let title: String
+    let value: String
+    let icon: String
+    let color: Color
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(color)
+            Text(value)
+                .font(.headline).fontWeight(.bold)
+                .foregroundStyle(Color.textPrimary)
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(Color.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .background(Color.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/ios/PetCare/PetCare/Views/Food/FoodPageView.swift
+++ b/ios/PetCare/PetCare/Views/Food/FoodPageView.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+struct FoodPageView: View {
+    var petSelector: PetSelectorViewModel
+    @State private var foodVM = FoodViewModel()
+    @State private var showCreateFood = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: 16) {
+                        HStack {
+                            Text("Food Database")
+                                .font(.headline).foregroundStyle(Color.textPrimary)
+                            Spacer()
+                            Button { showCreateFood = true } label: {
+                                Image(systemName: "plus.circle.fill")
+                                    .foregroundStyle(Color.accentPink)
+                            }
+                        }
+                        .padding(.horizontal)
+
+                        let columns = [GridItem(.flexible()), GridItem(.flexible())]
+                        LazyVGrid(columns: columns, spacing: 12) {
+                            ForEach(foodVM.foods) { food in
+                                FoodCard(food: food)
+                            }
+                        }
+                        .padding(.horizontal)
+
+                        if foodVM.foods.isEmpty && !foodVM.isLoading {
+                            Text("No foods in database yet")
+                                .foregroundStyle(Color.textTertiary)
+                                .padding(.top, 20)
+                        }
+                    }
+                    .padding(.top, 16)
+                }
+            }
+            .sheet(isPresented: $showCreateFood) {
+                CreateFoodSheet(petSelector: petSelector, foodVM: foodVM)
+            }
+            .onChange(of: petSelector.selectedPet?.groupId) { _, newGid in
+                guard let gid = newGid else { return }
+                Task { await foodVM.loadFoods(groupId: gid) }
+            }
+            .task {
+                if let gid = petSelector.selectedPet?.groupId { await foodVM.loadFoods(groupId: gid) }
+            }
+        }
+    }
+}
+
+struct FoodCard: View {
+    let food: Food
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if let url = food.photoUrl, let imageURL = URL(string: url) {
+                AsyncImage(url: imageURL) { image in
+                    image.resizable().scaledToFill()
+                } placeholder: {
+                    Image(systemName: "leaf.fill")
+                        .font(.title2).foregroundStyle(Color.accentTeal)
+                }
+                .frame(height: 80)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            } else {
+                Image(systemName: "leaf.fill")
+                    .font(.title2).foregroundStyle(Color.accentTeal)
+                    .frame(height: 60)
+            }
+
+            VStack(spacing: 2) {
+                if let brand = food.brand {
+                    Text(brand).font(.caption2).foregroundStyle(Color.textTertiary).lineLimit(1)
+                }
+                Text(food.productName ?? "Unknown")
+                    .font(.subheadline).fontWeight(.medium)
+                    .foregroundStyle(Color.textPrimary).lineLimit(1)
+
+                if let cal = food.caloriesPer100g {
+                    Text("\(Int(cal)) kcal/100g")
+                        .font(.caption).foregroundStyle(Color.accentPink)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(Color.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+struct CreateFoodSheet: View {
+    var petSelector: PetSelectorViewModel
+    var foodVM: FoodViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var brand = ""
+    @State private var productName = ""
+    @State private var caloriesPer100g = ""
+    @State private var foodType = "dry"
+    @State private var isCreating = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+                Form {
+                    Section("Basic Info") {
+                        TextField("Brand", text: $brand)
+                        TextField("Product Name", text: $productName)
+                        Picker("Type", selection: $foodType) {
+                            Text("Dry").tag("dry")
+                            Text("Wet").tag("wet")
+                            Text("Treat").tag("treat")
+                            Text("Other").tag("other")
+                        }
+                    }
+                    Section("Nutrition") {
+                        TextField("Calories per 100g", text: $caloriesPer100g)
+                            .keyboardType(.decimalPad)
+                    }
+                }
+                .scrollContentBackground(.hidden)
+            }
+            .navigationTitle("New Food")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        .disabled(productName.isEmpty || isCreating)
+                }
+            }
+        }
+    }
+
+    private func save() {
+        guard let gid = petSelector.selectedPet?.groupId else { return }
+        isCreating = true
+        Task {
+            let request = CreateFoodRequest(
+                brand: brand, productName: productName, foodType: foodType,
+                targetPet: nil, unitWeightG: nil,
+                caloriesPer100g: Double(caloriesPer100g),
+                proteinPercentage: nil, fatPercentage: nil,
+                moisturePercentage: nil, carbohydratePercentage: nil
+            )
+            _ = try? await foodVM.createFood(groupId: gid, request)
+            dismiss()
+        }
+    }
+}

--- a/ios/PetCare/PetCare/Views/HeaderView.swift
+++ b/ios/PetCare/PetCare/Views/HeaderView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+struct HeaderView: View {
+    let title: String
+    var petSelector: PetSelectorViewModel
+    var onRefresh: (() async -> Void)?
+    @State private var showPetPicker = false
+    @State private var isRefreshing = false
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(.title2).fontWeight(.bold)
+                .foregroundStyle(Color.textPrimary)
+
+            Spacer()
+
+            if let onRefresh {
+                Button {
+                    Task {
+                        isRefreshing = true
+                        await onRefresh()
+                        isRefreshing = false
+                    }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .foregroundStyle(Color.textSecondary)
+                        .rotationEffect(.degrees(isRefreshing ? 360 : 0))
+                        .animation(isRefreshing ? .linear(duration: 1).repeatForever(autoreverses: false) : .default, value: isRefreshing)
+                }
+            }
+
+            if petSelector.pets.count > 1 {
+                Button { showPetPicker = true } label: {
+                    HStack(spacing: 4) {
+                        Text(petSelector.selectedPet?.name ?? "Select Pet")
+                            .font(.subheadline).fontWeight(.medium)
+                            .lineLimit(1)
+                            .foregroundStyle(Color.textPrimary)
+                        Image(systemName: "chevron.down")
+                            .font(.caption)
+                            .foregroundStyle(Color.textSecondary)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Color.surface2)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .sheet(isPresented: $showPetPicker) {
+                    PetPickerSheet(petSelector: petSelector, isPresented: $showPetPicker)
+                        .presentationDetents([.medium])
+                }
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(Color.surface1)
+    }
+}
+
+struct PetPickerSheet: View {
+    var petSelector: PetSelectorViewModel
+    @Binding var isPresented: Bool
+
+    var body: some View {
+        NavigationStack {
+            List(petSelector.pets) { pet in
+                Button {
+                    petSelector.selectPet(pet)
+                    isPresented = false
+                } label: {
+                    HStack {
+                        if let url = pet.photoUrl, let imageURL = URL(string: url) {
+                            AsyncImage(url: imageURL) { image in
+                                image.resizable().scaledToFill()
+                            } placeholder: {
+                                Image(systemName: "pawprint.fill").foregroundStyle(Color.accentTeal)
+                            }
+                            .frame(width: 40, height: 40)
+                            .clipShape(Circle())
+                        } else {
+                            Image(systemName: "pawprint.fill")
+                                .frame(width: 40, height: 40)
+                                .foregroundStyle(Color.accentTeal)
+                        }
+
+                        VStack(alignment: .leading) {
+                            Text(pet.name)
+                                .fontWeight(.medium)
+                                .foregroundStyle(Color.textPrimary)
+                            if let breed = pet.breed {
+                                Text(breed)
+                                    .font(.caption)
+                                    .foregroundStyle(Color.textSecondary)
+                            }
+                        }
+                        Spacer()
+                        if pet.id == petSelector.selectedPet?.id {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(Color.accentPink)
+                        }
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(Color.surface0)
+            .navigationTitle("Select Pet")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}

--- a/ios/PetCare/PetCare/Views/LoginView.swift
+++ b/ios/PetCare/PetCare/Views/LoginView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct LoginView: View {
+    var authViewModel: AuthViewModel
+
+    var body: some View {
+        ZStack {
+            Color.surface0.ignoresSafeArea()
+
+            VStack(spacing: 32) {
+                Spacer()
+
+                Image(systemName: "pawprint.fill")
+                    .font(.system(size: 80))
+                    .foregroundStyle(Color.accentTeal)
+
+                Text("PetCare")
+                    .font(.largeTitle).fontWeight(.bold)
+                    .foregroundStyle(Color.textPrimary)
+
+                Text("Pet Health Tracker")
+                    .font(.subheadline)
+                    .foregroundStyle(Color.textSecondary)
+
+                Spacer()
+
+                Button {
+                    Task { await authViewModel.signInWithGoogle() }
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "globe")
+                            .font(.title3)
+                        Text("Sign in with Google")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(Color.surface1)
+                    .foregroundStyle(Color.textPrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.borderDefault, lineWidth: 1)
+                    )
+                }
+                .disabled(authViewModel.isLoading)
+                .padding(.horizontal, 40)
+
+                if authViewModel.isLoading {
+                    ProgressView("Signing in...")
+                        .tint(Color.accentTeal)
+                        .foregroundStyle(Color.textSecondary)
+                }
+
+                if let error = authViewModel.errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(Color.danger)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 40)
+                }
+
+                Spacer().frame(height: 60)
+            }
+        }
+    }
+}

--- a/ios/PetCare/PetCare/Views/MainTabView.swift
+++ b/ios/PetCare/PetCare/Views/MainTabView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct MainTabView: View {
+    var authViewModel: AuthViewModel
+    var petSelector: PetSelectorViewModel
+    @State private var selectedTab = 0
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            DashboardPageView(petSelector: petSelector)
+                .tabItem {
+                    Image(systemName: "chart.bar.fill")
+                    Text("Dashboard")
+                }
+                .tag(0)
+
+            MealPageView(petSelector: petSelector)
+                .tabItem {
+                    Image(systemName: "fork.knife")
+                    Text("Meals")
+                }
+                .tag(1)
+
+            MedicinePageView(petSelector: petSelector)
+                .tabItem {
+                    Image(systemName: "pills.fill")
+                    Text("Medicine")
+                }
+                .tag(2)
+
+            WeightPageView(petSelector: petSelector)
+                .tabItem {
+                    Image(systemName: "scalemass.fill")
+                    Text("Weight")
+                }
+                .tag(3)
+
+            SettingsPageView(authViewModel: authViewModel, petSelector: petSelector)
+                .tabItem {
+                    Image(systemName: "gearshape.fill")
+                    Text("Settings")
+                }
+                .tag(4)
+        }
+        .tint(Color.accentPink)
+        .onAppear {
+            let appearance = UITabBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = UIColor(Color.surface1)
+            appearance.stackedLayoutAppearance.normal.iconColor = UIColor(Color.textTertiary)
+            appearance.stackedLayoutAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor(Color.textTertiary)]
+            appearance.stackedLayoutAppearance.selected.iconColor = UIColor(Color.accentPink)
+            appearance.stackedLayoutAppearance.selected.titleTextAttributes = [.foregroundColor: UIColor(Color.accentPink)]
+            UITabBar.appearance().standardAppearance = appearance
+            UITabBar.appearance().scrollEdgeAppearance = appearance
+        }
+    }
+}

--- a/ios/PetCare/PetCare/Views/Meal/MealPageView.swift
+++ b/ios/PetCare/PetCare/Views/Meal/MealPageView.swift
@@ -1,0 +1,321 @@
+import SwiftUI
+import Charts
+
+struct MealPageView: View {
+    var petSelector: PetSelectorViewModel
+    @State private var mealVM = MealViewModel()
+    @State private var foodVM = FoodViewModel()
+    @State private var showCreateMeal = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: 16) {
+                        HeaderView(title: "Meals", petSelector: petSelector) {
+                            if let pet = petSelector.selectedPet {
+                                await mealVM.refresh(petId: pet.id)
+                            }
+                        }
+
+                        if let pet = petSelector.selectedPet {
+                            // Today's summary
+                            if let summary = mealVM.todaySummary {
+                                TodaySummaryCard(summary: summary, calorieTarget: pet.dailyCalorieTarget)
+                            }
+
+                            // Calorie chart
+                            if !mealVM.meals.isEmpty {
+                                CalorieChartCard(meals: mealVM.meals)
+                            }
+
+                            // Meals list
+                            MealListSection(meals: mealVM.meals)
+                        } else {
+                            Text("Select a pet to view meals")
+                                .foregroundStyle(Color.textTertiary)
+                                .padding(.top, 40)
+                        }
+                    }
+                }
+
+                // FAB
+                VStack {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        Button { showCreateMeal = true } label: {
+                            Image(systemName: "plus")
+                                .font(.title2).fontWeight(.bold)
+                                .foregroundStyle(.white)
+                                .frame(width: 56, height: 56)
+                                .background(Color.accentPink)
+                                .clipShape(Circle())
+                                .shadow(color: Color.accentPink.opacity(0.4), radius: 8, y: 4)
+                        }
+                        .padding(.trailing, 20)
+                        .padding(.bottom, 20)
+                    }
+                }
+            }
+            .navigationBarHidden(true)
+            .sheet(isPresented: $showCreateMeal) {
+                CreateMealSheet(petSelector: petSelector, foodVM: foodVM) {
+                    if let pet = petSelector.selectedPet {
+                        Task { await mealVM.refresh(petId: pet.id) }
+                    }
+                }
+            }
+            .onChange(of: petSelector.selectedPet?.id) { _, newId in
+                guard let petId = newId else { return }
+                Task {
+                    await mealVM.refresh(petId: petId)
+                    if let gid = petSelector.selectedPet?.groupId { await foodVM.loadFoods(groupId: gid) }
+                }
+            }
+            .task {
+                if let pet = petSelector.selectedPet {
+                    await mealVM.refresh(petId: pet.id)
+                    if let gid = pet.groupId { await foodVM.loadFoods(groupId: gid) }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Today Summary
+
+struct TodaySummaryCard: View {
+    let summary: TodaySummary
+    let calorieTarget: Int?
+
+    var progress: Double {
+        guard let target = calorieTarget, target > 0, let total = summary.totalCalories else { return 0 }
+        return min(total / Double(target), 1.0)
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Text("Today")
+                    .font(.headline).foregroundStyle(Color.textPrimary)
+                Spacer()
+                Text("\(Int(summary.totalCalories ?? 0)) / \(calorieTarget ?? 0) kcal")
+                    .font(.subheadline).foregroundStyle(Color.textSecondary)
+            }
+
+            ProgressView(value: progress)
+                .tint(progress > 0.9 ? Color.danger : Color.accentTeal)
+                .scaleEffect(y: 2, anchor: .center)
+
+            if let dist = summary.mealDistribution {
+                HStack(spacing: 0) {
+                    ForEach(["breakfast", "lunch", "dinner", "snack"], id: \.self) { type in
+                        VStack(spacing: 2) {
+                            Text("\(dist[type] ?? 0)")
+                                .font(.headline).foregroundStyle(Color.textPrimary)
+                            Text(type.capitalized)
+                                .font(.caption2).foregroundStyle(Color.textTertiary)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(Color.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal)
+    }
+}
+
+// MARK: - Calorie Chart
+
+struct CalorieChartCard: View {
+    let meals: [Meal]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Calorie Intake")
+                .font(.headline).foregroundStyle(Color.textPrimary)
+
+            Chart {
+                ForEach(meals, id: \.id) { meal in
+                    BarMark(
+                        x: .value("Date", meal.fedAt?.prefix(10).description ?? ""),
+                        y: .value("Calories", meal.calories ?? 0)
+                    )
+                    .foregroundStyle(colorForMealType(meal.mealType))
+                }
+            }
+            .chartYAxis {
+                AxisMarks { AxisGridLine().foregroundStyle(Color.borderSubtle) }
+            }
+            .frame(height: 200)
+        }
+        .padding()
+        .background(Color.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal)
+    }
+
+    private func colorForMealType(_ type: String?) -> Color {
+        switch type {
+        case "breakfast": return .chartPink
+        case "lunch": return .chartTeal
+        case "dinner": return .chartPurple
+        case "snack": return .chartBlue
+        default: return .chartGray
+        }
+    }
+}
+
+// MARK: - Meal List
+
+struct MealListSection: View {
+    let meals: [Meal]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Recent Meals")
+                .font(.headline).foregroundStyle(Color.textPrimary)
+                .padding(.horizontal)
+
+            if meals.isEmpty {
+                Text("No meals recorded yet")
+                    .foregroundStyle(Color.textTertiary)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+            } else {
+                ForEach(meals) { meal in
+                    MealRow(meal: meal)
+                }
+            }
+        }
+    }
+}
+
+struct MealRow: View {
+    let meal: Meal
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    if let type = meal.mealType {
+                        Text(type.capitalized)
+                            .font(.caption).fontWeight(.semibold)
+                            .padding(.horizontal, 8).padding(.vertical, 2)
+                            .background(Color.accentTeal.opacity(0.2))
+                            .foregroundStyle(Color.accentTeal)
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
+                    Text(meal.foodDetails?.displayName ?? "Unknown Food")
+                        .font(.subheadline).fontWeight(.medium)
+                        .foregroundStyle(Color.textPrimary)
+                        .lineLimit(1)
+                }
+                if let fedAt = meal.fedAt {
+                    Text(fedAt.prefix(16).replacingOccurrences(of: "T", with: " "))
+                        .font(.caption).foregroundStyle(Color.textTertiary)
+                }
+            }
+            Spacer()
+            Text("\(Int(meal.calories ?? 0)) kcal")
+                .font(.subheadline).fontWeight(.semibold)
+                .foregroundStyle(Color.accentPink)
+        }
+        .padding()
+        .background(Color.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal)
+    }
+}
+
+// MARK: - Create Meal Sheet
+
+struct CreateMealSheet: View {
+    var petSelector: PetSelectorViewModel
+    var foodVM: FoodViewModel
+    var onCreated: () -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedFoodId: String?
+    @State private var mealType = "breakfast"
+    @State private var servingAmount = ""
+    @State private var servingType = "grams"
+    @State private var isCreating = false
+    @State private var errorMessage: String?
+
+    let mealTypes = ["breakfast", "lunch", "dinner", "snack"]
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+                Form {
+                    Section("Food") {
+                        Picker("Select Food", selection: $selectedFoodId) {
+                            Text("Choose...").tag(nil as String?)
+                            ForEach(foodVM.foods) { food in
+                                Text(food.displayName).tag(food.id as String?)
+                            }
+                        }
+                    }
+                    Section("Details") {
+                        Picker("Meal Type", selection: $mealType) {
+                            ForEach(mealTypes, id: \.self) { Text($0.capitalized) }
+                        }
+                        TextField("Amount", text: $servingAmount)
+                            .keyboardType(.decimalPad)
+                        Picker("Serving Type", selection: $servingType) {
+                            ForEach(["grams", "units"], id: \.self) { Text($0.capitalized) }
+                        }
+                    }
+                    if let error = errorMessage {
+                        Section { Text(error).foregroundStyle(Color.danger) }
+                    }
+                }
+                .scrollContentBackground(.hidden)
+            }
+            .navigationTitle("Log Meal")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { createMeal() }
+                        .disabled(selectedFoodId == nil || isCreating)
+                }
+            }
+        }
+    }
+
+    private func createMeal() {
+        guard let petId = petSelector.selectedPet?.id, let foodId = selectedFoodId else { return }
+        isCreating = true
+        Task {
+            do {
+                let request = CreateMealRequest(
+                    petId: petId, foodId: foodId, mealType: mealType,
+                    servingType: servingType, servingAmount: Double(servingAmount),
+                    fedAt: nil, notes: nil
+                )
+                _ = try await APIClient.shared.createMeal(request)
+                onCreated()
+                dismiss()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isCreating = false
+        }
+    }
+}
+
+extension MealFoodDetails {
+    var displayName: String {
+        [brand, productName].compactMap { $0 }.joined(separator: " - ")
+    }
+}

--- a/ios/PetCare/PetCare/Views/Medicine/MedicinePageView.swift
+++ b/ios/PetCare/PetCare/Views/Medicine/MedicinePageView.swift
@@ -1,0 +1,345 @@
+import SwiftUI
+
+struct MedicinePageView: View {
+    var petSelector: PetSelectorViewModel
+    @State private var medicineVM = MedicineViewModel()
+    @State private var showCreateMedication = false
+    @State private var showCreateCourse = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: 16) {
+                        HeaderView(title: "Medicine", petSelector: petSelector) {
+                            if let pet = petSelector.selectedPet, let gid = pet.groupId {
+                                await medicineVM.refresh(petId: pet.id, groupId: gid)
+                            }
+                        }
+
+                        if let pet = petSelector.selectedPet {
+                            TodayChecklistSection(schedule: medicineVM.todaySchedule, medicineVM: medicineVM, petId: pet.id)
+                            ActiveCoursesSection(courses: medicineVM.courses, medicineVM: medicineVM, petId: pet.id, onAddCourse: { showCreateCourse = true })
+                            MedicationDatabaseSection(medications: medicineVM.medications, onAdd: { showCreateMedication = true })
+                        } else {
+                            Text("Select a pet to view medicine")
+                                .foregroundStyle(Color.textTertiary)
+                                .padding(.top, 40)
+                        }
+                    }
+                }
+            }
+            .navigationBarHidden(true)
+            .sheet(isPresented: $showCreateMedication) {
+                CreateMedicationSheet(petSelector: petSelector, medicineVM: medicineVM)
+            }
+            .sheet(isPresented: $showCreateCourse) {
+                CreateCourseSheet(petSelector: petSelector, medicineVM: medicineVM)
+            }
+            .onChange(of: petSelector.selectedPet?.id) { _, _ in loadAll() }
+            .task { loadAll() }
+        }
+    }
+
+    private func loadAll() {
+        guard let pet = petSelector.selectedPet, let gid = pet.groupId else { return }
+        Task { await medicineVM.refresh(petId: pet.id, groupId: gid) }
+    }
+}
+
+// MARK: - Today Checklist
+
+struct TodayChecklistSection: View {
+    let schedule: TodaySchedule?
+    var medicineVM: MedicineViewModel
+    let petId: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Today's Checklist")
+                    .font(.headline).foregroundStyle(Color.textPrimary)
+                Spacer()
+                if let cs = schedule?.completionStatus {
+                    Text("\(cs.totalCompleted ?? 0)/\(cs.totalRequired ?? 0)")
+                        .font(.caption).fontWeight(.bold)
+                        .padding(.horizontal, 8).padding(.vertical, 4)
+                        .background(Color.accentTeal.opacity(0.2))
+                        .foregroundStyle(Color.accentTeal)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+            }
+            .padding(.horizontal)
+
+            if let items = schedule?.scheduledCourses, !items.isEmpty {
+                ForEach(items) { item in
+                    ChecklistRow(item: item, medicineVM: medicineVM, petId: petId)
+                }
+            } else {
+                Text("No medications scheduled for today")
+                    .foregroundStyle(Color.textTertiary)
+                    .frame(maxWidth: .infinity).padding()
+            }
+        }
+    }
+}
+
+struct ChecklistRow: View {
+    let item: ScheduledCourseItem
+    var medicineVM: MedicineViewModel
+    let petId: String
+    @State private var isToggling = false
+
+    var body: some View {
+        HStack {
+            Image(systemName: "pills.fill")
+                .foregroundStyle(Color.accentPurple)
+                .frame(width: 32, height: 32)
+                .background(Color.accentPurple.opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.medicationName ?? "Unknown")
+                    .font(.subheadline).fontWeight(.medium)
+                    .foregroundStyle(Color.textPrimary)
+                if let dosage = item.dosage {
+                    Text(dosage).font(.caption).foregroundStyle(Color.textSecondary)
+                }
+            }
+
+            Spacer()
+
+            if isToggling {
+                ProgressView().tint(Color.accentTeal)
+            } else if item.isFullyDone {
+                Button {
+                    guard let log = item.completedLogs?.last else { return }
+                    isToggling = true
+                    Task {
+                        try? await medicineVM.undoDone(logId: log.logId ?? "", petId: petId)
+                        isToggling = false
+                    }
+                } label: {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.title2).foregroundStyle(Color.success)
+                }
+            } else {
+                Button {
+                    guard let cid = item.courseId else { return }
+                    isToggling = true
+                    Task {
+                        try? await medicineVM.markDone(courseId: cid, petId: petId)
+                        isToggling = false
+                    }
+                } label: {
+                    Image(systemName: "circle")
+                        .font(.title2).foregroundStyle(Color.textTertiary)
+                }
+            }
+        }
+        .padding()
+        .background(item.isFullyDone ? Color.success.opacity(0.05) : Color.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal)
+    }
+}
+
+// MARK: - Active Courses
+
+struct ActiveCoursesSection: View {
+    let courses: [TreatmentCourse]
+    var medicineVM: MedicineViewModel
+    let petId: String
+    var onAddCourse: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Active Courses")
+                    .font(.headline).foregroundStyle(Color.textPrimary)
+                Spacer()
+                Button { onAddCourse() } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .foregroundStyle(Color.accentPink)
+                }
+            }
+            .padding(.horizontal)
+
+            if courses.isEmpty {
+                Text("No active treatment courses")
+                    .foregroundStyle(Color.textTertiary)
+                    .frame(maxWidth: .infinity).padding()
+            } else {
+                ForEach(courses) { course in
+                    CourseRow(course: course)
+                }
+            }
+        }
+    }
+}
+
+struct CourseRow: View {
+    let course: TreatmentCourse
+
+    var body: some View {
+        HStack {
+            Image(systemName: "pills.fill")
+                .foregroundStyle(Color.accentBlue)
+                .frame(width: 32, height: 32)
+                .background(Color.accentBlue.opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(course.medicationName ?? "Unknown")
+                    .font(.subheadline).fontWeight(.medium)
+                    .foregroundStyle(Color.textPrimary)
+                HStack(spacing: 8) {
+                    if let dosage = course.dosage { Text(dosage).font(.caption).foregroundStyle(Color.textSecondary) }
+                    if let freq = course.frequencyDays { Text("Every \(freq)d").font(.caption).foregroundStyle(Color.textTertiary) }
+                }
+            }
+            Spacer()
+            if let start = course.startDate {
+                HStack(spacing: 2) {
+                    Image(systemName: "calendar").font(.caption2)
+                    Text(start.prefix(10)).font(.caption)
+                }
+                .foregroundStyle(Color.textTertiary)
+            }
+        }
+        .padding()
+        .background(Color.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal)
+    }
+}
+
+// MARK: - Medication Database
+
+struct MedicationDatabaseSection: View {
+    let medications: [Medication]
+    var onAdd: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Medication Database")
+                    .font(.headline).foregroundStyle(Color.textPrimary)
+                Spacer()
+                Button { onAdd() } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .foregroundStyle(Color.accentPink)
+                }
+            }
+            .padding(.horizontal)
+
+            let columns = [GridItem(.flexible()), GridItem(.flexible())]
+            LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(medications) { med in
+                    VStack(spacing: 6) {
+                        Image(systemName: "pills.fill")
+                            .font(.title2)
+                            .foregroundStyle(Color.accentPurple)
+                        Text(med.name)
+                            .font(.subheadline).fontWeight(.medium)
+                            .foregroundStyle(Color.textPrimary)
+                            .lineLimit(2).multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.surface1)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+}
+
+// MARK: - Create Sheets
+
+struct CreateMedicationSheet: View {
+    var petSelector: PetSelectorViewModel
+    var medicineVM: MedicineViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+                Form {
+                    Section("Medication Name") { TextField("Name", text: $name) }
+                }
+                .scrollContentBackground(.hidden)
+            }
+            .navigationTitle("New Medication")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        guard let gid = petSelector.selectedPet?.groupId else { return }
+                        Task { try? await medicineVM.createMedication(name: name, groupId: gid); dismiss() }
+                    }
+                    .disabled(name.isEmpty)
+                }
+            }
+        }
+    }
+}
+
+struct CreateCourseSheet: View {
+    var petSelector: PetSelectorViewModel
+    var medicineVM: MedicineViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedMedId: String?
+    @State private var dosage = ""
+    @State private var frequencyDays = "1"
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+                Form {
+                    Section("Medication") {
+                        Picker("Select", selection: $selectedMedId) {
+                            Text("Choose...").tag(nil as String?)
+                            ForEach(medicineVM.medications) { med in
+                                Text(med.name).tag(med.id as String?)
+                            }
+                        }
+                    }
+                    Section("Details") {
+                        TextField("Dosage (e.g. 1 tablet)", text: $dosage)
+                        TextField("Frequency (days)", text: $frequencyDays).keyboardType(.numberPad)
+                    }
+                }
+                .scrollContentBackground(.hidden)
+            }
+            .navigationTitle("New Course")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        guard let petId = petSelector.selectedPet?.id, let medId = selectedMedId else { return }
+                        Task {
+                            let req = CreateCourseRequest(
+                                petId: petId, medicationId: medId,
+                                dosage: dosage.isEmpty ? nil : dosage,
+                                frequencyDays: Int(frequencyDays),
+                                startDate: nil, endDate: nil
+                            )
+                            try? await medicineVM.createCourse(req, petId: petId)
+                            dismiss()
+                        }
+                    }
+                    .disabled(selectedMedId == nil)
+                }
+            }
+        }
+    }
+}

--- a/ios/PetCare/PetCare/Views/Settings/SettingsPageView.swift
+++ b/ios/PetCare/PetCare/Views/Settings/SettingsPageView.swift
@@ -1,0 +1,344 @@
+import SwiftUI
+
+struct SettingsPageView: View {
+    var authViewModel: AuthViewModel
+    var petSelector: PetSelectorViewModel
+    @State private var groupVM = GroupViewModel()
+    @State private var petVM = PetViewModel()
+    @State private var showCreatePet = false
+    @State private var showCreateGroup = false
+    @State private var showJoinGroup = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: 16) {
+                        HeaderView(title: "Settings", petSelector: petSelector)
+
+                        // User profile
+                        if let user = authViewModel.user {
+                            UserProfileCard(user: user)
+                        }
+
+                        // My Pets
+                        MyPetsSection(pets: petSelector.pets, onCreatePet: { showCreatePet = true })
+
+                        // Groups
+                        GroupsSection(groupVM: groupVM, onCreateGroup: { showCreateGroup = true }, onJoinGroup: { showJoinGroup = true })
+
+                        // Actions
+                        VStack(spacing: 12) {
+                            Button { authViewModel.logout() } label: {
+                                HStack {
+                                    Image(systemName: "rectangle.portrait.and.arrow.right")
+                                    Text("Sign Out")
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 14)
+                                .background(Color.danger.opacity(0.15))
+                                .foregroundStyle(Color.danger)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                            }
+                        }
+                        .padding(.horizontal)
+                        .padding(.bottom, 40)
+                    }
+                }
+            }
+            .navigationBarHidden(true)
+            .sheet(isPresented: $showCreatePet) {
+                CreatePetSheet(petSelector: petSelector)
+            }
+            .sheet(isPresented: $showCreateGroup) {
+                CreateGroupSheet(groupVM: groupVM)
+            }
+            .sheet(isPresented: $showJoinGroup) {
+                JoinGroupSheet(groupVM: groupVM)
+            }
+            .task { await groupVM.loadGroups() }
+        }
+    }
+}
+
+// MARK: - User Profile
+
+struct UserProfileCard: View {
+    let user: User
+
+    var body: some View {
+        HStack(spacing: 16) {
+            if let pic = user.picture, let url = URL(string: pic) {
+                AsyncImage(url: url) { image in
+                    image.resizable().scaledToFill()
+                } placeholder: { ProgressView() }
+                .frame(width: 56, height: 56).clipShape(Circle())
+            } else {
+                Image(systemName: "person.circle.fill")
+                    .font(.system(size: 48)).foregroundStyle(Color.accentTeal)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(user.name)
+                    .font(.headline).foregroundStyle(Color.textPrimary)
+                Text(user.email)
+                    .font(.subheadline).foregroundStyle(Color.textSecondary)
+            }
+            Spacer()
+        }
+        .padding()
+        .background(Color.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal)
+    }
+}
+
+// MARK: - My Pets
+
+struct MyPetsSection: View {
+    let pets: [PetInfo]
+    var onCreatePet: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("My Pets")
+                    .font(.headline).foregroundStyle(Color.textPrimary)
+                Spacer()
+                Button { onCreatePet() } label: {
+                    Image(systemName: "plus.circle.fill").foregroundStyle(Color.accentPink)
+                }
+            }
+            .padding(.horizontal)
+
+            ForEach(pets) { pet in
+                HStack(spacing: 12) {
+                    if let url = pet.photoUrl, let imageURL = URL(string: url) {
+                        AsyncImage(url: imageURL) { image in
+                            image.resizable().scaledToFill()
+                        } placeholder: {
+                            Image(systemName: "pawprint.fill").foregroundStyle(Color.accentTeal)
+                        }
+                        .frame(width: 44, height: 44).clipShape(Circle())
+                    } else {
+                        Image(systemName: "pawprint.fill")
+                            .foregroundStyle(Color.accentTeal)
+                            .frame(width: 44, height: 44)
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(pet.name).font(.subheadline).fontWeight(.medium).foregroundStyle(Color.textPrimary)
+                        HStack(spacing: 4) {
+                            if let breed = pet.breed { Text(breed).font(.caption).foregroundStyle(Color.textSecondary) }
+                            if let gn = pet.groupName {
+                                Text(gn).font(.caption2).padding(.horizontal, 6).padding(.vertical, 1)
+                                    .background(Color.accentBlue.opacity(0.15)).foregroundStyle(Color.accentBlue)
+                                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                            }
+                        }
+                    }
+                    Spacer()
+                }
+                .padding()
+                .background(Color.surface1)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .padding(.horizontal)
+            }
+        }
+    }
+}
+
+// MARK: - Groups
+
+struct GroupsSection: View {
+    var groupVM: GroupViewModel
+    var onCreateGroup: () -> Void
+    var onJoinGroup: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Groups")
+                    .font(.headline).foregroundStyle(Color.textPrimary)
+                Spacer()
+                Button { onJoinGroup() } label: {
+                    Text("Join").font(.subheadline).foregroundStyle(Color.accentTeal)
+                }
+                Button { onCreateGroup() } label: {
+                    Image(systemName: "plus.circle.fill").foregroundStyle(Color.accentPink)
+                }
+            }
+            .padding(.horizontal)
+
+            if groupVM.groups.isEmpty {
+                Text("No groups yet").foregroundStyle(Color.textTertiary)
+                    .frame(maxWidth: .infinity).padding()
+            } else {
+                ForEach(groupVM.groups) { group in
+                    GroupRow(group: group)
+                }
+            }
+        }
+    }
+}
+
+struct GroupRow: View {
+    let group: Group
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(group.name)
+                    .font(.subheadline).fontWeight(.medium).foregroundStyle(Color.textPrimary)
+                HStack(spacing: 6) {
+                    if let role = group.role {
+                        Text(role.capitalized)
+                            .font(.caption2).fontWeight(.semibold)
+                            .padding(.horizontal, 6).padding(.vertical, 2)
+                            .background(roleColor(role).opacity(0.15))
+                            .foregroundStyle(roleColor(role))
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
+                    if let count = group.memberCount {
+                        HStack(spacing: 2) {
+                            Image(systemName: "person.2.fill").font(.caption2)
+                            Text("\(count)").font(.caption)
+                        }
+                        .foregroundStyle(Color.textTertiary)
+                    }
+                }
+            }
+            Spacer()
+        }
+        .padding()
+        .background(Color.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal)
+    }
+
+    private func roleColor(_ role: String) -> Color {
+        switch role {
+        case "creator": return .accentPink
+        case "member": return .accentTeal
+        default: return .accentBlue
+        }
+    }
+}
+
+// MARK: - Create / Join Sheets
+
+struct CreatePetSheet: View {
+    var petSelector: PetSelectorViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+    @State private var petType: PetType = .dog
+    @State private var breed = ""
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+                Form {
+                    Section("Pet Info") {
+                        TextField("Name", text: $name)
+                        Picker("Type", selection: $petType) {
+                            ForEach(PetType.allCases, id: \.self) { Text($0.rawValue.capitalized) }
+                        }
+                        TextField("Breed (optional)", text: $breed)
+                    }
+                }
+                .scrollContentBackground(.hidden)
+            }
+            .navigationTitle("New Pet").navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task {
+                            let req = CreatePetRequest(name: name, petType: petType, breed: breed.isEmpty ? nil : breed, gender: nil, birthDate: nil, currentWeightKg: nil, targetWeightKg: nil, dailyCalorieTarget: nil, notes: nil)
+                            _ = try? await APIClient.shared.createPet(req)
+                            await petSelector.loadPets()
+                            dismiss()
+                        }
+                    }
+                    .disabled(name.isEmpty)
+                }
+            }
+        }
+    }
+}
+
+struct CreateGroupSheet: View {
+    var groupVM: GroupViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+                Form { Section("Group Name") { TextField("Name", text: $name) } }
+                    .scrollContentBackground(.hidden)
+            }
+            .navigationTitle("New Group").navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task { _ = try? await groupVM.createGroup(name: name); dismiss() }
+                    }
+                    .disabled(name.isEmpty)
+                }
+            }
+        }
+    }
+}
+
+struct JoinGroupSheet: View {
+    var groupVM: GroupViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var inviteCode = ""
+    @State private var preview: InvitationPreview?
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+                Form {
+                    Section("Invite Code") {
+                        TextField("Enter code", text: $inviteCode)
+                    }
+                    if let p = preview {
+                        Section("Preview") {
+                            Text("Group: \(p.groupName)")
+                            Text("Invited by: \(p.inviterName)")
+                            Text("Role: \(p.role)")
+                            Button("Join Group") {
+                                Task { try? await groupVM.joinGroup(inviteCode: inviteCode); dismiss() }
+                            }
+                            .foregroundStyle(Color.accentTeal)
+                        }
+                    }
+                    if let error = errorMessage {
+                        Section { Text(error).foregroundStyle(Color.danger) }
+                    }
+                }
+                .scrollContentBackground(.hidden)
+            }
+            .navigationTitle("Join Group").navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Look Up") {
+                        Task {
+                            do { preview = try await groupVM.previewInvitation(inviteCode: inviteCode) }
+                            catch { errorMessage = error.localizedDescription }
+                        }
+                    }
+                    .disabled(inviteCode.isEmpty)
+                }
+            }
+        }
+    }
+}

--- a/ios/PetCare/PetCare/Views/Weight/WeightPageView.swift
+++ b/ios/PetCare/PetCare/Views/Weight/WeightPageView.swift
@@ -1,0 +1,234 @@
+import SwiftUI
+import Charts
+
+struct WeightPageView: View {
+    var petSelector: PetSelectorViewModel
+    @State private var weightVM = WeightViewModel()
+    @State private var showCreateWeight = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: 16) {
+                        HeaderView(title: "Weight", petSelector: petSelector) {
+                            if let pet = petSelector.selectedPet { await weightVM.loadRecords(petId: pet.id) }
+                        }
+
+                        if petSelector.selectedPet != nil {
+                            if !weightVM.records.isEmpty {
+                                WeightChartCard(records: weightVM.records)
+                                WeightStatsRow(vm: weightVM)
+                            }
+                            WeightRecordsList(records: weightVM.records)
+                        } else {
+                            Text("Select a pet to view weight records")
+                                .foregroundStyle(Color.textTertiary)
+                                .padding(.top, 40)
+                        }
+                    }
+                }
+
+                VStack {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        Button { showCreateWeight = true } label: {
+                            Image(systemName: "plus")
+                                .font(.title2).fontWeight(.bold)
+                                .foregroundStyle(.white)
+                                .frame(width: 56, height: 56)
+                                .background(Color.accentTeal)
+                                .clipShape(Circle())
+                                .shadow(color: Color.accentTeal.opacity(0.4), radius: 8, y: 4)
+                        }
+                        .padding(.trailing, 20).padding(.bottom, 20)
+                    }
+                }
+            }
+            .navigationBarHidden(true)
+            .sheet(isPresented: $showCreateWeight) {
+                CreateWeightSheet(petSelector: petSelector) {
+                    if let pet = petSelector.selectedPet {
+                        Task { await weightVM.loadRecords(petId: pet.id) }
+                    }
+                }
+            }
+            .onChange(of: petSelector.selectedPet?.id) { _, newId in
+                guard let petId = newId else { return }
+                Task { await weightVM.loadRecords(petId: petId) }
+            }
+            .task {
+                if let pet = petSelector.selectedPet { await weightVM.loadRecords(petId: pet.id) }
+            }
+        }
+    }
+}
+
+struct WeightChartCard: View {
+    let records: [WeightRecord]
+
+    var chartRecords: [WeightRecord] {
+        Array(records.reversed().suffix(30))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Weight Trend")
+                .font(.headline).foregroundStyle(Color.textPrimary)
+
+            Chart(chartRecords, id: \.id) { record in
+                LineMark(
+                    x: .value("Date", record.timestamp?.prefix(10).description ?? ""),
+                    y: .value("Weight", record.weightKg)
+                )
+                .foregroundStyle(Color.accentTeal)
+                .interpolationMethod(.catmullRom)
+
+                PointMark(
+                    x: .value("Date", record.timestamp?.prefix(10).description ?? ""),
+                    y: .value("Weight", record.weightKg)
+                )
+                .foregroundStyle(Color.accentTeal)
+                .symbolSize(30)
+            }
+            .chartYAxis {
+                AxisMarks { AxisGridLine().foregroundStyle(Color.borderSubtle) }
+            }
+            .frame(height: 200)
+        }
+        .padding()
+        .background(Color.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal)
+    }
+}
+
+struct WeightStatsRow: View {
+    let vm: WeightViewModel
+
+    var body: some View {
+        HStack(spacing: 12) {
+            StatCard(title: "Records", value: "\(vm.totalRecords)", icon: "number", color: .accentBlue)
+            StatCard(title: "Average", value: vm.averageWeight.map { String(format: "%.1f kg", $0) } ?? "—", icon: "divide", color: .accentPurple)
+            StatCard(title: "Change", value: vm.weightChange.map { String(format: "%+.1f kg", $0) } ?? "—", icon: "arrow.up.arrow.down", color: .accentTeal)
+        }
+        .padding(.horizontal)
+    }
+}
+
+struct WeightRecordsList: View {
+    let records: [WeightRecord]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Records")
+                .font(.headline).foregroundStyle(Color.textPrimary)
+                .padding(.horizontal)
+
+            if records.isEmpty {
+                Text("No weight records yet")
+                    .foregroundStyle(Color.textTertiary)
+                    .frame(maxWidth: .infinity).padding()
+            } else {
+                ForEach(Array(records.enumerated()), id: \.element.id) { index, record in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text(String(format: "%.2f kg", record.weightKg))
+                                    .font(.title3).fontWeight(.bold)
+                                    .foregroundStyle(Color.textPrimary)
+                                if index == 0 {
+                                    Text("Latest")
+                                        .font(.caption2).fontWeight(.bold)
+                                        .padding(.horizontal, 6).padding(.vertical, 2)
+                                        .background(Color.accentTeal.opacity(0.2))
+                                        .foregroundStyle(Color.accentTeal)
+                                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                                }
+                            }
+                            if let ts = record.timestamp {
+                                Text(ts.prefix(16).replacingOccurrences(of: "T", with: " "))
+                                    .font(.caption).foregroundStyle(Color.textTertiary)
+                            }
+                            if let notes = record.notes, !notes.isEmpty {
+                                Text(notes)
+                                    .font(.caption).foregroundStyle(Color.textSecondary)
+                            }
+                        }
+                        Spacer()
+                        if let by = record.recordedByName {
+                            HStack(spacing: 4) {
+                                Image(systemName: "person.fill")
+                                    .font(.caption2)
+                                Text(by).font(.caption)
+                            }
+                            .foregroundStyle(Color.textTertiary)
+                        }
+                    }
+                    .padding()
+                    .background(index == 0 ? Color.accentTeal.opacity(0.05) : Color.surface1)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .padding(.horizontal)
+                }
+            }
+        }
+    }
+}
+
+struct CreateWeightSheet: View {
+    var petSelector: PetSelectorViewModel
+    var onCreated: () -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var weightStr = ""
+    @State private var notes = ""
+    @State private var isCreating = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.surface0.ignoresSafeArea()
+                Form {
+                    Section("Weight") {
+                        TextField("Weight (kg)", text: $weightStr)
+                            .keyboardType(.decimalPad)
+                    }
+                    Section("Notes") {
+                        TextField("Optional notes", text: $notes)
+                    }
+                    if let error = errorMessage {
+                        Section { Text(error).foregroundStyle(Color.danger) }
+                    }
+                }
+                .scrollContentBackground(.hidden)
+            }
+            .navigationTitle("Add Weight")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }.disabled(weightStr.isEmpty || isCreating)
+                }
+            }
+        }
+    }
+
+    private func save() {
+        guard let petId = petSelector.selectedPet?.id, let weight = Double(weightStr) else { return }
+        isCreating = true
+        Task {
+            do {
+                let request = CreateWeightRequest(petId: petId, weightKg: weight, timestamp: nil, notes: notes.isEmpty ? nil : notes)
+                _ = try await APIClient.shared.createWeight(request)
+                onCreated()
+                dismiss()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isCreating = false
+        }
+    }
+}


### PR DESCRIPTION
Closes #95
Closes #96
Closes #97
Closes #98
Closes #99
Closes #100
Closes #101
Closes #102
Closes #103

## Summary
- Full iOS SwiftUI app migrating all PetCare PWA features to native iOS
- 29 Swift files across Models, Services, ViewModels, Views, and Theme layers
- Dark theme color tokens matching website's `tokens.css` exactly
- All backend API endpoints consumed via shared `APIClient` singleton with 401 auto-logout
- 5-tab navigation (Dashboard, Meals, Medicine, Weight, Settings) matching PWA layout

## Files changed by layer
- **Theme**: `Colors.swift` — all design tokens from `tokens.css`
- **Models**: `AuthModels`, `PetModels`, `UserModels`, `GroupModels`, `FoodModels`, `MealModels`, `WeightModels`, `MedicineModels`
- **Services**: `APIClient.swift` — full rewrite with GET/POST, 401 handling, file upload, all domain endpoints
- **ViewModels**: `AuthViewModel`, `PetSelectorViewModel`, `PetViewModel`, `GroupViewModel`, `FoodViewModel`, `MealViewModel`, `WeightViewModel`, `MedicineViewModel`
- **Views**: `LoginView`, `MainTabView`, `HeaderView` (pet selector), `DashboardPageView` (pet summary + stats), `MealPageView` (today summary + chart + list + create), `WeightPageView` (chart + stats + list + create), `MedicinePageView` (checklist + courses + DB + create), `FoodPageView` (grid + create), `SettingsPageView` (profile + pets + groups + logout)
- **Navigation**: `ContentView` (auth routing + session restore), `PetCareApp` (entry point)

## Backend endpoints consumed
- `POST /auth/google/login` — auth_router.py
- `GET /user/me` — user_router.py:29
- `POST /user/update` — user_router.py:45
- `POST /user/photo/upload` — user_router.py:67
- `GET /pets/accessible` — pet_router.py:53
- `GET /pets/{id}/details` — pet_router.py:225
- `POST /pets/create` — pet_router.py:17
- `POST /pets/{id}/update` — pet_router.py:86
- `POST /pets/{id}/photo/upload` — pet_router.py:270
- `POST /pets/{id}/assign_group` — pet_router.py:152
- `GET /groups/my_groups` — group_router.py:121
- `GET /groups/{id}/members` — group_router.py:137
- `GET /groups/{id}/pets` — group_router.py:237
- `POST /groups/create` — group_router.py:23
- `POST /groups/delete/{id}` — group_router.py:209
- `POST /groups/{id}/invite` — group_router.py:44
- `GET /groups/invitation/{code}` — group_router.py:71
- `POST /groups/join` — group_router.py:98
- `GET /foods/info?group_id=` — food_router.py:191
- `GET /foods/{id}/details` — food_router.py:17
- `POST /foods/create?group_id=` — food_router.py:133
- `POST /foods/{id}/update` — food_router.py:49
- `POST /foods/{id}/delete` — food_router.py:95
- `POST /foods/{id}/photo/upload` — food_router.py:251
- `GET /meals?pet_id=` — meal_router.py:68
- `GET /meals/{id}/details` — meal_router.py:137
- `GET /meals/today?pet_id=` — meal_router.py:269
- `GET /meals/summary?pet_id=` — meal_router.py:338
- `POST /meals` — meal_router.py:17
- `POST /meals/{id}/update` — meal_router.py:173
- `POST /meals/{id}/delete` — meal_router.py:228
- `GET /weights/info?pet_id=` — weight_router.py:153
- `POST /weights/create` — weight_router.py:17
- `POST /weights/update/{id}` — weight_router.py:65
- `POST /weights/delete/{id}` — weight_router.py:112
- `GET /medicine/list?group_id=` — medicine_router.py:61
- `GET /medicine/{id}` — medicine_router.py:227
- `POST /medicine/create` — medicine_router.py:44
- `POST /medicine/{id}/update` — medicine_router.py:192
- `POST /medicine/{id}/delete` — medicine_router.py:210
- `GET /medicine/course/list?pet_id=` — medicine_router.py:134
- `POST /medicine/course/create` — medicine_router.py:81
- `POST /medicine/course/{id}/end` — medicine_router.py:116
- `GET /medicine/today?pet_id=` — medicine_router.py:23
- `POST /medicine/log/create` — medicine_router.py:155
- `POST /medicine/log/{id}/delete` — medicine_router.py:172

## React parity reference
- Consulted all frontend components, services, slices, hooks, and types
- Parity: full — all 5 tabs and all CRUD operations covered
- iOS uses Swift Charts instead of MUI X-Charts
- iOS uses `@Observable` instead of Redux Toolkit
- Color tokens in `Colors.swift` map 1:1 to `tokens.css`

## Manual test plan (Xcode simulator)
1. Open app → should show login screen with dark theme
2. Sign in with Google → should navigate to TabView with 5 tabs
3. Dashboard: pet summary card + quick stats (weight, target, cal/day)
4. Meals: today summary + calorie chart + recent meals list + tap + to create meal
5. Weight: weight trend chart + stats + record list + tap + to add weight
6. Medicine: today checklist (mark done/undo) + active courses + medication database
7. Settings: user profile + pets list + groups + create pet/group + join group + logout
8. Kill app and reopen → should auto-restore session (no re-login)
9. Pet selector in header → switch between pets, all data reloads

## New files to add to Xcode project
All 29 `.swift` files need to be added to the Xcode project:
1. Open the Xcode project at `ios/PetCare/PetCare.xcodeproj`
2. Right-click the `PetCare` group → "Add Files to PetCare"
3. Select the folders: `Theme/`, `Models/`, `Services/`, `ViewModels/`, `Views/`
4. Check "Create groups" and target "PetCare" → Add
5. Also add `ContentView.swift` and `PetCareApp.swift` if they show as missing

## Notes
- `APIClient.baseURL` is set to `https://petcare-staging.onrender.com` — change for production
- Auth token stored in UserDefaults (POC level) — migrate to Keychain for production
- Xcode `.xcodeproj` not modified — user must add files manually
- No `print()` in production code (only behind `#if DEBUG`)