### PR TITLE
[#105] Add refresh_tokens table to database schema

### DIFF
--- a/database/db_schema.sql
+++ b/database/db_schema.sql
@@ -220,6 +220,30 @@ update
     public.access_tokens for each row execute function update_updated_at_column();
 
 
+-- refresh tokens table
+CREATE TABLE refresh_tokens (
+	id serial4 NOT NULL,
+	"token" text NOT NULL,
+	user_id varchar(8) NOT NULL,
+	access_token_id int4 NOT NULL,
+	expires_at timestamptz NOT NULL,
+	is_active bool DEFAULT true,
+	created_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	updated_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	CONSTRAINT refresh_tokens_pkey PRIMARY KEY (id),
+	CONSTRAINT refresh_tokens_token_unique UNIQUE ("token"),
+	CONSTRAINT refresh_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE,
+	CONSTRAINT refresh_tokens_access_token_id_fkey FOREIGN KEY (access_token_id) REFERENCES public.access_tokens(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_refresh_tokens_token ON public.refresh_tokens USING btree ("token");
+CREATE INDEX idx_refresh_tokens_user_id ON public.refresh_tokens USING btree (user_id, is_active);
+
+create trigger update_refresh_tokens_updated_at before
+update
+    on
+    public.refresh_tokens for each row execute function update_updated_at_column();
+
+
 -- api keys table
 CREATE TABLE api_keys (
 	id serial4 NOT NULL,


### PR DESCRIPTION
Closes #105

## Summary
- Add `refresh_tokens` table to `database/db_schema.sql` for long-lived refresh token storage
- Includes unique constraint on token, FK to users and access_tokens, indexes, and updated_at trigger

## Files changed by layer
- **Schema**: `database/db_schema.sql` — new `refresh_tokens` table

## Manual test plan
```sql
-- Verify table exists
\dt refresh_tokens

-- Verify indexes
\di refresh_tokens*

-- Verify trigger
INSERT INTO refresh_tokens (token, user_id, access_token_id, expires_at)
VALUES ('test_token', '<valid_user_id>', 1, NOW() + INTERVAL '30 days');
UPDATE refresh_tokens SET is_active = false WHERE token = 'test_token';
SELECT updated_at FROM refresh_tokens WHERE token = 'test_token';
-- updated_at should be > created_at
```

## Manual SQL to run
```sql
CREATE TABLE refresh_tokens (
    id serial4 NOT NULL,
    "token" text NOT NULL,
    user_id varchar(8) NOT NULL,
    access_token_id int4 NOT NULL,
    expires_at timestamptz NOT NULL,
    is_active bool DEFAULT true,
    created_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
    updated_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
    CONSTRAINT refresh_tokens_pkey PRIMARY KEY (id),
    CONSTRAINT refresh_tokens_token_unique UNIQUE ("token"),
    CONSTRAINT refresh_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE,
    CONSTRAINT refresh_tokens_access_token_id_fkey FOREIGN KEY (access_token_id) REFERENCES public.access_tokens(id) ON DELETE CASCADE
);
CREATE INDEX idx_refresh_tokens_token ON public.refresh_tokens USING btree ("token");
CREATE INDEX idx_refresh_tokens_user_id ON public.refresh_tokens USING btree (user_id, is_active);
CREATE TRIGGER update_refresh_tokens_updated_at BEFORE UPDATE ON public.refresh_tokens FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
```

## Notes
- Pure additive change — no existing tables modified
- FK to access_tokens uses ON DELETE CASCADE so when an access token is cleaned up, its associated refresh token is also removed