### PR TITLE
[#106] Add refresh token support to auth backend

### DIFF
--- a/backend/models/auth.py
+++ b/backend/models/auth.py
@@ -9,10 +9,12 @@ from pydantic import BaseModel
 load_dotenv("backend/.env")
 
 ACCESS_TOKEN_EXPIRE_MINUTES = 120
+REFRESH_TOKEN_EXPIRE_DAYS = 30
 ALGORITHM = "HS256"
 ACCESS_TOKEN_SECRET_KEY = os.getenv("JWT_SECRET_KEY")
 
 access_token_table = "access_tokens"
+refresh_token_table = "refresh_tokens"
 api_key_table = "api_keys"
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/access_token")
@@ -42,6 +44,10 @@ class AccessToken(BaseModel):
 class EmailAuthRequest(BaseModel):
     email: str
     pwd: str
+
+
+class RefreshTokenRequest(BaseModel):
+    refresh_token: str
 
 
 class APIKey(BaseModel):

--- a/backend/routers/auth_router.py
+++ b/backend/routers/auth_router.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
 
-from backend.models.auth import EmailAuthRequest, GoogleAuthRequest
+from backend.models.auth import EmailAuthRequest, GoogleAuthRequest, RefreshTokenRequest
 from backend.services.auth_service import AuthService
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -23,6 +23,7 @@ async def validate_email_login_route(request: EmailAuthRequest) -> dict:
         "data": {
             "access_token": token_info["access_token"],
             "token_type": token_info["token_type"],
+            "refresh_token": token_info["refresh_token"],
             "user": {
                 "id": user.id,
                 "email": user.email,
@@ -47,6 +48,7 @@ async def validate_google_login_route(request: GoogleAuthRequest) -> dict:
         "data": {
             "access_token": token_info["access_token"],
             "token_type": token_info["token_type"],
+            "refresh_token": token_info["refresh_token"],
             "user": {
                 "id": user.id,
                 "email": user.email,
@@ -55,6 +57,21 @@ async def validate_google_login_route(request: GoogleAuthRequest) -> dict:
             },
         },
         "message": "Google login successful",
+    }
+
+
+@router.post("/token/refresh")
+async def refresh_token_route(request: RefreshTokenRequest) -> dict:
+    token_info = await auth_service.refresh_access_token(request.refresh_token)
+
+    return {
+        "status": 1,
+        "data": {
+            "access_token": token_info["access_token"],
+            "token_type": token_info["token_type"],
+            "refresh_token": token_info["refresh_token"],
+        },
+        "message": "Token refreshed successfully",
     }
 
 

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 import uuid
 from datetime import datetime as dt
 from datetime import timedelta as td
@@ -14,12 +15,14 @@ from backend.models.auth import (
     ACCESS_TOKEN_EXPIRE_MINUTES,
     ACCESS_TOKEN_SECRET_KEY,
     ALGORITHM,
+    REFRESH_TOKEN_EXPIRE_DAYS,
     AccessToken,
     access_token_table,
     api_key_scheme,
     api_key_table,
     oauth2_scheme,
     pwd_context,
+    refresh_token_table,
 )
 from backend.models.group import CreateGroupRequest
 from backend.models.user import User, UserInfo, user_table
@@ -82,18 +85,37 @@ class AuthService:
         existing_token = await self.find_valid_token(user_id)
 
         if existing_token:
-            return {
-                "access_token": existing_token.token,
-                "token_type": "bearer",
-            }
+            access_token_str = existing_token.token
         else:
             access_token = self.create_access_token(user_id=user_id)
             await self.db.insert_one(access_token_table, access_token.model_dump())
+            access_token_str = access_token.token
 
-            return {
-                "access_token": access_token.token,
-                "token_type": "bearer",
-            }
+        # Look up access_token row id for refresh token FK
+        at_row = await self.db.read_one(
+            f"SELECT id FROM {access_token_table} WHERE token = '{access_token_str}' AND is_active = True"
+        )
+        access_token_id = at_row["id"] if at_row else 1
+
+        # Always create a fresh refresh token on login
+        refresh_token_str = secrets.token_urlsafe(64)
+        refresh_expires = dt.now(tz.utc) + td(days=REFRESH_TOKEN_EXPIRE_DAYS)
+        await self.db.insert_one(
+            refresh_token_table,
+            {
+                "token": refresh_token_str,
+                "user_id": user_id,
+                "access_token_id": access_token_id,
+                "expires_at": refresh_expires,
+                "is_active": True,
+            },
+        )
+
+        return {
+            "access_token": access_token_str,
+            "token_type": "bearer",
+            "refresh_token": refresh_token_str,
+        }
 
     async def authenticate_google_user(self, token: str) -> Optional[User]:
         google_user_info = await self.google_provider.verify_token(token)
@@ -141,6 +163,63 @@ class AuthService:
             """
             await self.db.execute(query)
             return new_user
+
+    async def refresh_access_token(self, refresh_token_str: str) -> dict:
+        """Validate a refresh token and issue a new access + refresh token pair."""
+        sql = f"""
+        SELECT * FROM {refresh_token_table}
+        WHERE token = '{refresh_token_str}'
+          AND is_active = True
+          AND expires_at > CURRENT_TIMESTAMP
+        """
+        rt = await self.db.read_one(sql)
+
+        if not rt:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or expired refresh token",
+            )
+
+        user_id = rt["user_id"]
+
+        # Revoke the used refresh token
+        await self.db.execute(f"UPDATE {refresh_token_table} SET is_active = False WHERE id = {rt['id']}")
+
+        # Create new access token
+        access_token = self.create_access_token(user_id=user_id)
+        await self.db.insert_one(access_token_table, access_token.model_dump())
+
+        # Look up the new access token id
+        at_row = await self.db.read_one(
+            f"SELECT id FROM {access_token_table} WHERE token = '{access_token.token}' AND is_active = True"
+        )
+        new_at_id = at_row["id"] if at_row else 1
+
+        # Create new refresh token
+        new_refresh = secrets.token_urlsafe(64)
+        refresh_expires = dt.now(tz.utc) + td(days=REFRESH_TOKEN_EXPIRE_DAYS)
+        await self.db.insert_one(
+            refresh_token_table,
+            {
+                "token": new_refresh,
+                "user_id": user_id,
+                "access_token_id": new_at_id,
+                "expires_at": refresh_expires,
+                "is_active": True,
+            },
+        )
+
+        return {
+            "access_token": access_token.token,
+            "token_type": "bearer",
+            "refresh_token": new_refresh,
+        }
+
+    async def revoke_refresh_tokens(self, user_id: str) -> None:
+        """Revoke all active refresh tokens for a user (called on logout)."""
+        await self.db.execute(
+            f"UPDATE {refresh_token_table} SET is_active = False WHERE user_id = '{user_id}' AND is_active = True"
+        )
 
     def verify_password(self, password: str, hashed_pwd: str) -> bool:
         return pwd_context.verify(password, hashed_pwd)


### PR DESCRIPTION
Closes #106

## Summary
- Add refresh token mechanism to auth backend (30-day expiry)
- Login endpoints now return `refresh_token` alongside `access_token`
- New `POST /auth/token/refresh` endpoint for silent token renewal
- Refresh tokens are revoked on use (single-use) and new ones are issued

## Files changed by layer
- **Models**: `backend/models/auth.py` — `REFRESH_TOKEN_EXPIRE_DAYS`, `refresh_token_table`, `RefreshTokenRequest`
- **Services**: `backend/services/auth_service.py` — `refresh_access_token()`, `revoke_refresh_tokens()`, modified `get_or_create_token()`
- **Routers**: `backend/routers/auth_router.py` — new `POST /auth/token/refresh`, modified google/email login responses

## Manual test plan
```bash
# 1. Login and get refresh token
curl -X POST https://petcare-staging.onrender.com/auth/google/login \
  -H "Content-Type: application/json" \
  -d '{"token": "<google_id_token>"}'
# Response should include "refresh_token" field

# 2. Use refresh token to get new access token
curl -X POST https://petcare-staging.onrender.com/auth/token/refresh \
  -H "Content-Type: application/json" \
  -d '{"refresh_token": "<refresh_token_from_step_1>"}'
# Should return new access_token + new refresh_token

# 3. Try to reuse the old refresh token (should fail)
curl -X POST https://petcare-staging.onrender.com/auth/token/refresh \
  -H "Content-Type: application/json" \
  -d '{"refresh_token": "<refresh_token_from_step_1>"}'
# Should return 401
```

## Notes
- Refresh tokens are single-use: each refresh revokes the old token and issues a new pair
- No JWT auth header required for `/auth/token/refresh` (by design — the access token is expired)
- `revoke_refresh_tokens()` method available for logout integration (not wired to a logout endpoint yet — no logout endpoint exists in the current codebase)