### PR TITLE
[#107] Add Keychain storage and silent token refresh to iOS app

### DIFF
--- a/ios/PetCare/PetCare/ContentView.swift
+++ b/ios/PetCare/PetCare/ContentView.swift
@@ -1,37 +1,31 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var authViewModel = AuthViewModel()
+    @State private var authViewModel: AuthViewModel
     @State private var petSelector = PetSelectorViewModel()
-    @State private var isRestoringSession = true
+
+    init() {
+        // Read token from Keychain — if present, assume logged in immediately.
+        // Background validation will kick us out via 401 if the token is expired.
+        let savedToken = KeychainHelper.read(forKey: KeychainHelper.accessTokenKey)
+        _authViewModel = State(initialValue: AuthViewModel(restoredToken: savedToken))
+    }
 
     var body: some View {
-        Group {
-            if isRestoringSession {
-                ZStack {
-                    Color.surface0.ignoresSafeArea()
-                    VStack(spacing: 16) {
-                        Image(systemName: "pawprint.fill")
-                            .font(.system(size: 48))
-                            .foregroundStyle(Color.accentTeal)
-                        ProgressView()
-                            .tint(Color.accentTeal)
-                    }
-                }
-            } else if authViewModel.isLoggedIn {
+        SwiftUI.Group {
+            if authViewModel.isLoggedIn {
                 MainTabView(authViewModel: authViewModel, petSelector: petSelector)
             } else {
                 LoginView(authViewModel: authViewModel)
             }
         }
         .animation(.easeInOut(duration: 0.3), value: authViewModel.isLoggedIn)
-        .animation(.easeInOut(duration: 0.3), value: isRestoringSession)
         .task {
-            await authViewModel.restoreSession()
             if authViewModel.isLoggedIn {
-                await petSelector.loadPets()
+                async let petsTask: () = petSelector.loadPets()
+                async let userTask: () = authViewModel.validateSession()
+                _ = await (petsTask, userTask)
             }
-            isRestoringSession = false
         }
         .onChange(of: authViewModel.isLoggedIn) { _, isLoggedIn in
             if isLoggedIn {

--- a/ios/PetCare/PetCare/Models/AuthModels.swift
+++ b/ios/PetCare/PetCare/Models/AuthModels.swift
@@ -6,6 +6,14 @@ struct GoogleLoginRequest: Codable {
     let token: String
 }
 
+struct RefreshTokenRequest: Codable {
+    let refreshToken: String
+
+    enum CodingKeys: String, CodingKey {
+        case refreshToken = "refresh_token"
+    }
+}
+
 // MARK: - Response envelope
 
 struct APIResponse<T: Codable>: Codable {
@@ -19,12 +27,28 @@ struct APIResponse<T: Codable>: Codable {
 struct LoginResponseData: Codable {
     let accessToken: String
     let tokenType: String
+    let refreshToken: String
     let user: User
 
     enum CodingKeys: String, CodingKey {
         case accessToken = "access_token"
         case tokenType = "token_type"
+        case refreshToken = "refresh_token"
         case user
+    }
+}
+
+// MARK: - Refresh response data
+
+struct RefreshResponseData: Codable {
+    let accessToken: String
+    let tokenType: String
+    let refreshToken: String
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case refreshToken = "refresh_token"
     }
 }
 

--- a/ios/PetCare/PetCare/Services/APIClient.swift
+++ b/ios/PetCare/PetCare/Services/APIClient.swift
@@ -17,8 +17,10 @@ final class APIClient {
         decoder = JSONDecoder()
     }
 
+    private var isRefreshing = false
+
     private var token: String? {
-        UserDefaults.standard.string(forKey: "petcare_token")
+        KeychainHelper.read(forKey: KeychainHelper.accessTokenKey)
     }
 
     // MARK: - Auth
@@ -26,7 +28,24 @@ final class APIClient {
     func googleLogin(idToken: String) async throws -> LoginResponseData {
         let body = GoogleLoginRequest(token: idToken)
         let response: APIResponse<LoginResponseData> = try await post(path: "/auth/google/login", body: body, authenticated: false)
-        return try unwrap(response)
+        let data = try unwrap(response)
+        // Save tokens to Keychain
+        KeychainHelper.save(data.accessToken, forKey: KeychainHelper.accessTokenKey)
+        KeychainHelper.save(data.refreshToken, forKey: KeychainHelper.refreshTokenKey)
+        return data
+    }
+
+    func refreshTokens() async throws -> RefreshResponseData {
+        guard let refreshToken = KeychainHelper.read(forKey: KeychainHelper.refreshTokenKey) else {
+            throw APIError.unauthorized
+        }
+        let body = RefreshTokenRequest(refreshToken: refreshToken)
+        let response: APIResponse<RefreshResponseData> = try await post(path: "/auth/token/refresh", body: body, authenticated: false)
+        let data = try unwrap(response)
+        // Save new tokens to Keychain
+        KeychainHelper.save(data.accessToken, forKey: KeychainHelper.accessTokenKey)
+        KeychainHelper.save(data.refreshToken, forKey: KeychainHelper.refreshTokenKey)
+        return data
     }
 
     func fetchCurrentUser() async throws -> UserInfo {
@@ -314,6 +333,47 @@ final class APIClient {
         guard let http = httpResponse as? HTTPURLResponse else { throw APIError.invalidResponse }
 
         if http.statusCode == 401 {
+            // Try silent refresh if we have a refresh token and aren't already refreshing
+            if !isRefreshing, KeychainHelper.read(forKey: KeychainHelper.refreshTokenKey) != nil {
+                isRefreshing = true
+                do {
+                    _ = try await refreshTokens()
+                    isRefreshing = false
+                    // Retry the original request with the new token
+                    var retryRequest = request
+                    if let newToken = token {
+                        retryRequest.setValue("Bearer \(newToken)", forHTTPHeaderField: "Authorization")
+                    }
+                    return try await executeWithoutRetry(retryRequest)
+                } catch {
+                    isRefreshing = false
+                    // Refresh failed — clear tokens and notify
+                    KeychainHelper.deleteAll()
+                    await MainActor.run { NotificationCenter.default.post(name: Self.unauthorizedNotification, object: nil) }
+                    throw APIError.unauthorized
+                }
+            }
+            // No refresh token or already refreshing — give up
+            KeychainHelper.deleteAll()
+            await MainActor.run { NotificationCenter.default.post(name: Self.unauthorizedNotification, object: nil) }
+            throw APIError.unauthorized
+        }
+
+        guard (200...299).contains(http.statusCode) else {
+            let message = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw APIError.httpError(statusCode: http.statusCode, message: message)
+        }
+
+        return try decoder.decode(APIResponse<Response>.self, from: data)
+    }
+
+    /// Execute without 401 retry (used for retried requests after refresh)
+    private func executeWithoutRetry<Response: Codable>(_ request: URLRequest) async throws -> APIResponse<Response> {
+        let (data, httpResponse) = try await session.data(for: request)
+        guard let http = httpResponse as? HTTPURLResponse else { throw APIError.invalidResponse }
+
+        if http.statusCode == 401 {
+            KeychainHelper.deleteAll()
             await MainActor.run { NotificationCenter.default.post(name: Self.unauthorizedNotification, object: nil) }
             throw APIError.unauthorized
         }

--- a/ios/PetCare/PetCare/Services/KeychainHelper.swift
+++ b/ios/PetCare/PetCare/Services/KeychainHelper.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Security
+
+enum KeychainHelper {
+    private static let service = "com.petcare.app"
+
+    static func save(_ value: String, forKey key: String) {
+        guard let data = value.data(using: .utf8) else { return }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+        // Delete any existing item first
+        SecItemDelete(query as CFDictionary)
+
+        var addQuery = query
+        addQuery[kSecValueData as String] = data
+        SecItemAdd(addQuery as CFDictionary, nil)
+    }
+
+    static func read(forKey key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func delete(forKey key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    static func deleteAll() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    // Key constants
+    static let accessTokenKey = "petcare_access_token"
+    static let refreshTokenKey = "petcare_refresh_token"
+}

--- a/ios/PetCare/PetCare/ViewModels/AuthViewModel.swift
+++ b/ios/PetCare/PetCare/ViewModels/AuthViewModel.swift
@@ -9,14 +9,25 @@ final class AuthViewModel {
     var errorMessage: String?
     private var unauthorizedObserver: Any?
 
-    var isLoggedIn: Bool { accessToken != nil && user != nil }
+    var isLoggedIn: Bool { accessToken != nil }
 
+    /// Default init (no token)
     init() {
-        // Listen for 401 notifications from APIClient
+        setupUnauthorizedObserver()
+    }
+
+    /// Init with a restored token from Keychain — assume logged in immediately
+    init(restoredToken: String?) {
+        self.accessToken = restoredToken
+        setupUnauthorizedObserver()
+    }
+
+    private func setupUnauthorizedObserver() {
         unauthorizedObserver = NotificationCenter.default.addObserver(
             forName: APIClient.unauthorizedNotification, object: nil, queue: .main
         ) { [weak self] _ in
-            self?.logout()
+            guard let self else { return }
+            Task { @MainActor in self.logout() }
         }
     }
 
@@ -26,18 +37,16 @@ final class AuthViewModel {
         }
     }
 
-    /// Try to restore session from persisted token on app launch
+    /// Validate the token in background — if invalid, 401 handler will auto-logout
     @MainActor
-    func restoreSession() async {
-        guard let savedToken = UserDefaults.standard.string(forKey: "petcare_token") else { return }
-        self.accessToken = savedToken
+    func validateSession() async {
+        guard accessToken != nil else { return }
         do {
             let userInfo = try await APIClient.shared.fetchCurrentUser()
             self.user = User(id: userInfo.id, email: userInfo.email, name: userInfo.name, picture: userInfo.picture)
         } catch {
-            // Token is invalid — clear it
-            self.accessToken = nil
-            UserDefaults.standard.removeObject(forKey: "petcare_token")
+            // 401 triggers the unauthorized observer → auto logout
+            // Other errors: might be a network blip, don't logout
         }
     }
 
@@ -59,9 +68,9 @@ final class AuthViewModel {
                 return
             }
             let loginData = try await APIClient.shared.googleLogin(idToken: idToken)
+            // Tokens are saved to Keychain inside APIClient.googleLogin()
             self.accessToken = loginData.accessToken
             self.user = loginData.user
-            UserDefaults.standard.set(loginData.accessToken, forKey: "petcare_token")
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -73,6 +82,8 @@ final class AuthViewModel {
         GIDSignIn.sharedInstance.signOut()
         accessToken = nil
         user = nil
+        KeychainHelper.deleteAll()
+        // Also clean up legacy UserDefaults token if it exists
         UserDefaults.standard.removeObject(forKey: "petcare_token")
     }
 }


### PR DESCRIPTION
Closes #107

## Summary
- Replace UserDefaults token storage with Keychain (encrypted, secure)
- Add silent refresh on 401: APIClient tries refresh token before logging out
- Login now saves both access_token + refresh_token to Keychain
- Logout clears all Keychain entries

## Files changed by layer
- **Models**: `AuthModels.swift` — add `refreshToken` to `LoginResponseData`, add `RefreshTokenRequest`, `RefreshResponseData`
- **Services**: New `KeychainHelper.swift` — save/read/delete from Keychain. `APIClient.swift` — Keychain-based token, silent 401 refresh with retry
- **ViewModels**: `AuthViewModel.swift` — Keychain for login/logout, remove UserDefaults
- **Navigation**: `ContentView.swift` — read token from Keychain

## Backend endpoints consumed
- `POST /auth/google/login` — backend/routers/auth_router.py:38 (now returns `refresh_token`)
- `POST /auth/token/refresh` — backend/routers/auth_router.py:63 (new endpoint from #106)
- `GET /user/me` — backend/routers/user_router.py:29

## Manual test plan (Xcode simulator)
1. Login via Google → verify tokens saved (app stays logged in)
2. Kill app, reopen → session restored from Keychain (no re-login)
3. Logout → Keychain cleared, returns to login screen
4. Access token expires → next API call silently refreshes (no login screen)

## New files to add to Xcode project
- `ios/PetCare/PetCare/Services/KeychainHelper.swift`
- (right-click Services group → Add Files to "PetCare" → select KeychainHelper.swift)

## Notes
- Legacy `petcare_token` in UserDefaults is cleaned up on logout (migration path)
- Refresh is single-use: old refresh token revoked, new one issued
- `isRefreshing` flag prevents concurrent refresh attempts