### PR TITLE
[#108] Add refresh token support to PWA frontend

### DIFF
--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -210,21 +210,32 @@ class TestFindValidToken:
 class TestGetOrCreateToken:
     @pytest.mark.asyncio
     async def test_returns_existing_token_without_inserting(self, auth_service, mock_db):
-        # Arrange: existing valid token in DB
-        mock_db.read_one.return_value = _make_token_row(token="cached.jwt.token")
+        # Arrange: first read_one returns existing token, second returns access_token id
+        mock_db.read_one.side_effect = [
+            _make_token_row(token="cached.jwt.token"),  # find_valid_token
+            {"id": 42},  # look up access_token id for refresh token FK
+        ]
 
         # Act
         result = await auth_service.get_or_create_token("u_test01")
 
-        # Assert: returns the cached token
-        assert result == {"access_token": "cached.jwt.token", "token_type": "bearer"}
-        # Assert: no insert happened
-        assert mock_db.insert_one.await_count == 0
+        # Assert: returns the cached token + a refresh token
+        assert result["access_token"] == "cached.jwt.token"
+        assert result["token_type"] == "bearer"
+        assert "refresh_token" in result
+        # Assert: no access_token insert, but one refresh_token insert
+        assert mock_db.insert_one.await_count == 1
+        table_arg = mock_db.insert_one.await_args.args[0]
+        assert table_arg == "refresh_tokens"
 
     @pytest.mark.asyncio
     async def test_creates_new_token_when_none_exists(self, auth_service, mock_db):
-        # Arrange: no existing token
-        mock_db.read_one.return_value = None
+        # Arrange: first read_one returns None (no existing token),
+        # second returns access_token id for refresh token FK
+        mock_db.read_one.side_effect = [
+            None,  # find_valid_token
+            {"id": 99},  # look up access_token id
+        ]
 
         # Act
         result = await auth_service.get_or_create_token("u_test01")
@@ -232,12 +243,14 @@ class TestGetOrCreateToken:
         # Assert: returns a new token wrapped in the dict envelope
         assert result["token_type"] == "bearer"
         assert isinstance(result["access_token"], str) and len(result["access_token"]) > 0
+        assert "refresh_token" in result
 
-        # Assert: persisted to access_tokens table
-        assert mock_db.insert_one.await_count == 1
-        table_arg, payload_arg = mock_db.insert_one.await_args.args
-        assert table_arg == "access_tokens"
-        assert payload_arg["user_id"] == "u_test01"
+        # Assert: two inserts — one for access_tokens, one for refresh_tokens
+        assert mock_db.insert_one.await_count == 2
+        first_call_table = mock_db.insert_one.await_args_list[0].args[0]
+        second_call_table = mock_db.insert_one.await_args_list[1].args[0]
+        assert first_call_table == "access_tokens"
+        assert second_call_table == "refresh_tokens"
 
 
 # ================================================================

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,9 +1,11 @@
-import axios, { type AxiosInstance } from 'axios';
+import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from 'axios';
 
 class ApiClient {
     private client: AxiosInstance;
     private baseUrl: string;
     private isHandling401 = false;
+    private isRefreshing = false;
+    private refreshPromise: Promise<string | null> | null = null;
 
     constructor(environment: string) {
         if (environment === 'prod') {
@@ -17,8 +19,6 @@ class ApiClient {
         this.client = axios.create({
             baseURL: this.baseUrl,
             timeout: 10000,
-            // Don't set default Content-Type here
-            // Let axios automatically set it based on request data
         });
 
         this.setupInterceptors();
@@ -26,7 +26,6 @@ class ApiClient {
 
     private setupInterceptors() {
         this.client.interceptors.request.use((config) => {
-            // Add auth token if not present
             if (!config.headers.Authorization) {
                 const token = localStorage.getItem('petcare_token');
                 if (token) {
@@ -34,15 +33,11 @@ class ApiClient {
                 }
             }
 
-            // Only process JSON data, skip FormData (for file uploads)
             if (config.data && ['post', 'put', 'patch'].includes(config.method?.toLowerCase() || '')) {
-                // Check if data is FormData (for file uploads)
                 if (!(config.data instanceof FormData)) {
-                    // Set Content-Type for JSON and clean undefined values
                     config.headers['Content-Type'] = 'application/json';
                     config.data = this.removeUndefined(config.data);
                 }
-                // If it's FormData, axios will automatically set the correct Content-Type with boundary
             }
 
             return config;
@@ -52,13 +47,77 @@ class ApiClient {
 
         this.client.interceptors.response.use(
             (response) => response,
-            (error) => {
-                if (error.response?.status === 401 && !this.isHandling401) {
-                    this.handle401Error();
+            async (error) => {
+                const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+
+                if (error.response?.status === 401 && !originalRequest._retry) {
+                    // Skip refresh for auth endpoints themselves
+                    const isAuthEndpoint = originalRequest.url?.includes('/auth/');
+                    if (isAuthEndpoint) {
+                        return Promise.reject(error);
+                    }
+
+                    originalRequest._retry = true;
+
+                    const refreshToken = localStorage.getItem('petcare_refresh_token');
+                    if (refreshToken) {
+                        try {
+                            const newToken = await this.tryRefresh(refreshToken);
+                            if (newToken) {
+                                originalRequest.headers.Authorization = `Bearer ${newToken}`;
+                                return this.client(originalRequest);
+                            }
+                        } catch {
+                            // Refresh failed — fall through to logout
+                        }
+                    }
+
+                    // No refresh token or refresh failed — logout
+                    if (!this.isHandling401) {
+                        this.handle401Error();
+                    }
                 }
                 return Promise.reject(error);
             }
         );
+    }
+
+    private async tryRefresh(refreshToken: string): Promise<string | null> {
+        // If already refreshing, wait for the in-progress refresh
+        if (this.isRefreshing && this.refreshPromise) {
+            return this.refreshPromise;
+        }
+
+        this.isRefreshing = true;
+        this.refreshPromise = this.doRefresh(refreshToken);
+
+        try {
+            const result = await this.refreshPromise;
+            return result;
+        } finally {
+            this.isRefreshing = false;
+            this.refreshPromise = null;
+        }
+    }
+
+    private async doRefresh(refreshToken: string): Promise<string | null> {
+        try {
+            const response = await axios.post(`${this.baseUrl}/auth/token/refresh`, {
+                refresh_token: refreshToken,
+            });
+
+            const data = response.data;
+            if (data.status === 1 && data.data) {
+                localStorage.setItem('petcare_token', data.data.access_token);
+                localStorage.setItem('petcare_refresh_token', data.data.refresh_token);
+                return data.data.access_token;
+            }
+            return null;
+        } catch {
+            // Refresh token is invalid/expired — clear it
+            localStorage.removeItem('petcare_refresh_token');
+            return null;
+        }
     }
 
     private handle401Error() {
@@ -69,17 +128,15 @@ class ApiClient {
         const isAuthPage = currentPath === '/login' || currentPath === '/signup';
 
         if (!isAuthPage) {
-            console.log('🔒 ApiClient: 401 detected, clearing auth and redirecting to login');
-
-            // 清理本地儲存
             localStorage.removeItem('petcare_token');
+            localStorage.removeItem('petcare_refresh_token');
             localStorage.removeItem('petcare_user_id');
             localStorage.removeItem('petcare_user_email');
             localStorage.removeItem('petcare_user_name');
+            localStorage.removeItem('petcare_user_picture');
             localStorage.removeItem('petcare_selected_pet');
 
             window.dispatchEvent(new CustomEvent('auth:logout'));
-
             window.location.href = '/login';
         }
 
@@ -103,7 +160,6 @@ class ApiClient {
                 cleaned[key] = value;
             }
         }
-        console.log(cleaned);
         return cleaned as T;
     }
 }

--- a/frontend/src/api/services/AuthService.ts
+++ b/frontend/src/api/services/AuthService.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "../client";
-import type { EmailLoginRequest, GoogleLoginRequest, LoginResponse, ApiResponse } from "../../types";
+import type { EmailLoginRequest, GoogleLoginRequest, LoginResponse, RefreshTokenRequest, RefreshTokenResponse, ApiResponse } from "../../types";
 
 class AuthService {
     private basePath = '/auth';
@@ -11,6 +11,11 @@ class AuthService {
 
     async googleLogin(request: GoogleLoginRequest): Promise<ApiResponse<LoginResponse>> {
         const response = await apiClient.post(`${this.basePath}/google/login`, request);
+        return response.data;
+    }
+
+    async refreshToken(request: RefreshTokenRequest): Promise<ApiResponse<RefreshTokenResponse>> {
+        const response = await apiClient.post(`${this.basePath}/token/refresh`, request);
         return response.data;
     }
 }

--- a/frontend/src/store/slices/authSlice.ts
+++ b/frontend/src/store/slices/authSlice.ts
@@ -31,8 +31,8 @@ export const loginUser = createAsyncThunk(
       });
 
       if (response.status === 1 && response.data) {
-        // Store token in localStorage
         localStorage.setItem('petcare_token', response.data.access_token);
+        localStorage.setItem('petcare_refresh_token', response.data.refresh_token);
         localStorage.setItem('petcare_user_id', response.data.user.id);
         localStorage.setItem('petcare_user_email', response.data.user.email);
         localStorage.setItem('petcare_user_name', response.data.user.name);
@@ -60,8 +60,8 @@ export const loginGoogleUser = createAsyncThunk(
       });
 
       if (response.status === 1 && response.data) {
-        // Store token in localStorage
         localStorage.setItem('petcare_token', response.data.access_token);
+        localStorage.setItem('petcare_refresh_token', response.data.refresh_token);
         localStorage.setItem('petcare_user_id', response.data.user.id);
         localStorage.setItem('petcare_user_email', response.data.user.email);
         localStorage.setItem('petcare_user_name', response.data.user.name);
@@ -164,6 +164,7 @@ const authSlice = createSlice({
     logout: (state) => {
       // Clear localStorage
       localStorage.removeItem('petcare_token');
+      localStorage.removeItem('petcare_refresh_token');
       localStorage.removeItem('petcare_user_id');
       localStorage.removeItem('petcare_user_email');
       localStorage.removeItem('petcare_user_name');

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -21,7 +21,18 @@ export interface SignupRequest {
 export interface LoginResponse {
   access_token: string;
   token_type: string;
+  refresh_token: string;
   user: User;
+}
+
+export interface RefreshTokenRequest {
+  refresh_token: string;
+}
+
+export interface RefreshTokenResponse {
+  access_token: string;
+  token_type: string;
+  refresh_token: string;
 }
 
 // App Auth State


### PR DESCRIPTION
Closes #108

## Summary
- Add silent token refresh on 401 in the PWA axios interceptor
- Login thunks now save `petcare_refresh_token` to localStorage
- Logout clears refresh token from localStorage
- On 401: attempt `POST /auth/token/refresh` → on success, retry original request seamlessly

## Files changed by layer
- **Types**: `src/types/auth.ts` — add `refresh_token` to `LoginResponse`, add `RefreshTokenRequest`, `RefreshTokenResponse`
- **API services**: `src/api/services/AuthService.ts` — add `refreshToken()` method
- **API client**: `src/api/client.ts` — rewrite 401 interceptor: try refresh before logout, retry original request, deduplicate concurrent refreshes via promise sharing
- **Store / slices**: `src/store/slices/authSlice.ts` — save `petcare_refresh_token` on email/google login, clear on logout

## Backend endpoints consumed
- `POST /auth/token/refresh` — backend/routers/auth_router.py:63

## Manual test plan
1. Login (Google or email) → open DevTools → Application → localStorage → confirm `petcare_refresh_token` exists
2. Delete `petcare_token` from localStorage (simulating expiry) → navigate to any page → network tab shows `/auth/token/refresh` call → new token saved → user stays logged in
3. Delete both `petcare_token` and `petcare_refresh_token` → next API call → redirected to `/login`
4. Logout → confirm both tokens cleared from localStorage

## Mobile viewport check
- No UI changes — this is a pure API/state layer change

## Notes
- Refresh call uses raw `axios.post()` (not the interceptor-wrapped client) to avoid infinite 401 loops
- Concurrent 401s from multiple API calls are deduplicated via a shared `refreshPromise`
- `console.log` removed from `removeUndefined` method (was left from previous debug session)