### PR TITLE
[#113] Add CacheManager and DataStore for iOS local data caching

### DIFF
--- a/ios/PetCare/PetCare/ContentView.swift
+++ b/ios/PetCare/PetCare/ContentView.swift
@@ -2,28 +2,25 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var authViewModel: AuthViewModel
-    @State private var petSelector = PetSelectorViewModel()
+    @State private var dataStore = DataStore()
     @State private var showLaunch = true
 
     init() {
-        // Read token from Keychain — if present, assume logged in immediately.
         let savedToken = KeychainHelper.read(forKey: KeychainHelper.accessTokenKey)
         _authViewModel = State(initialValue: AuthViewModel(restoredToken: savedToken))
     }
 
     var body: some View {
         ZStack {
-            // Main content underneath
             SwiftUI.Group {
                 if authViewModel.isLoggedIn {
-                    MainTabView(authViewModel: authViewModel, petSelector: petSelector)
+                    MainTabView(authViewModel: authViewModel, dataStore: dataStore)
                 } else {
                     LoginView(authViewModel: authViewModel)
                 }
             }
             .animation(.easeInOut(duration: 0.3), value: authViewModel.isLoggedIn)
 
-            // Launch screen on top — disappears after animation
             if showLaunch {
                 LaunchScreenView()
                     .transition(.opacity)
@@ -31,25 +28,32 @@ struct ContentView: View {
             }
         }
         .task {
-            // Show launch animation for at least 1.5s so it feels intentional
-            try? await Task.sleep(for: .seconds(1.5))
+            if authViewModel.isLoggedIn {
+                // Load cached data instantly (synchronous)
+                dataStore.loadFromCache()
+            }
+
+            // Show launch animation for at least 1.2s
+            try? await Task.sleep(for: .seconds(1.2))
             withAnimation(.easeOut(duration: 0.4)) {
                 showLaunch = false
             }
 
             if authViewModel.isLoggedIn {
-                async let petsTask: () = petSelector.loadPets()
+                // Background: validate session + refresh all data from API
                 async let userTask: () = authViewModel.validateSession()
-                _ = await (petsTask, userTask)
+                async let preloadTask: () = dataStore.preloadAll()
+                _ = await (userTask, preloadTask)
             }
         }
         .onChange(of: authViewModel.isLoggedIn) { _, isLoggedIn in
             if isLoggedIn {
-                Task { await petSelector.loadPets() }
+                Task {
+                    dataStore.loadFromCache()
+                    await dataStore.preloadAll()
+                }
             } else {
-                petSelector.pets = []
-                petSelector.selectedPet = nil
-                petSelector.selectedPetDetails = nil
+                dataStore.clearAll()
             }
         }
     }

--- a/ios/PetCare/PetCare/Services/CacheManager.swift
+++ b/ios/PetCare/PetCare/Services/CacheManager.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Generic JSON cache backed by UserDefaults.
+/// Keys are namespaced as "cache_{domain}_{scope}" to avoid collisions.
+/// Each entry stores data + a timestamp for stale-while-revalidate.
+enum CacheManager {
+    private static let defaults = UserDefaults.standard
+    private static let maxAgeSeconds: TimeInterval = 300 // 5 minutes
+
+    // MARK: - Save
+
+    static func save<T: Encodable>(_ value: T, forKey key: String) {
+        guard let data = try? JSONEncoder().encode(value) else { return }
+        let entry = CacheEntry(data: data, timestamp: Date())
+        guard let entryData = try? JSONEncoder().encode(entry) else { return }
+        defaults.set(entryData, forKey: cacheKey(key))
+    }
+
+    // MARK: - Load
+
+    static func load<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
+        guard let entryData = defaults.data(forKey: cacheKey(key)),
+              let entry = try? JSONDecoder().decode(CacheEntry.self, from: entryData),
+              let value = try? JSONDecoder().decode(type, from: entry.data) else {
+            return nil
+        }
+        return value
+    }
+
+    /// Returns true if the cached entry is older than maxAgeSeconds
+    static func isStale(forKey key: String) -> Bool {
+        guard let entryData = defaults.data(forKey: cacheKey(key)),
+              let entry = try? JSONDecoder().decode(CacheEntry.self, from: entryData) else {
+            return true // No cache = stale
+        }
+        return Date().timeIntervalSince(entry.timestamp) > maxAgeSeconds
+    }
+
+    // MARK: - Delete
+
+    static func remove(forKey key: String) {
+        defaults.removeObject(forKey: cacheKey(key))
+    }
+
+    static func clearAll() {
+        let allKeys = defaults.dictionaryRepresentation().keys
+        for key in allKeys where key.hasPrefix("petcare_cache_") {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    // MARK: - Key helpers
+
+    private static func cacheKey(_ key: String) -> String {
+        "petcare_cache_\(key)"
+    }
+
+    /// Standard cache keys for each domain
+    static func petsKey() -> String { "pets" }
+    static func petDetailsKey(_ petId: String) -> String { "pet_details_\(petId)" }
+    static func groupsKey() -> String { "groups" }
+    static func foodsKey(_ groupId: String) -> String { "foods_\(groupId)" }
+    static func mealsKey(_ petId: String) -> String { "meals_\(petId)" }
+    static func todaySummaryKey(_ petId: String) -> String { "today_summary_\(petId)" }
+    static func weightsKey(_ petId: String) -> String { "weights_\(petId)" }
+    static func medicationsKey(_ groupId: String) -> String { "medications_\(groupId)" }
+    static func coursesKey(_ petId: String) -> String { "courses_\(petId)" }
+    static func todayScheduleKey(_ petId: String) -> String { "today_schedule_\(petId)" }
+}
+
+// MARK: - Internal
+
+private struct CacheEntry: Codable {
+    let data: Data
+    let timestamp: Date
+}

--- a/ios/PetCare/PetCare/ViewModels/DataStore.swift
+++ b/ios/PetCare/PetCare/ViewModels/DataStore.swift
@@ -1,0 +1,291 @@
+import Foundation
+
+/// Centralized data store — holds all domain data in memory,
+/// backed by CacheManager for persistence across app launches.
+/// Views read from here (instant), background refresh keeps data fresh.
+@Observable
+final class DataStore {
+    // MARK: - Domain data
+
+    var pets: [PetInfo] = []
+    var selectedPet: PetInfo?
+    var selectedPetDetails: PetDetails?
+    var groups: [PetGroup] = []
+    var foods: [Food] = []
+    var meals: [Meal] = []
+    var todaySummary: TodaySummary?
+    var weightRecords: [WeightRecord] = []
+    var weightTotal: Int = 0
+    var medications: [Medication] = []
+    var courses: [TreatmentCourse] = []
+    var todaySchedule: TodaySchedule?
+
+    var isPreloading = false
+
+    // MARK: - Computed
+
+    var currentPetId: String? { selectedPet?.id }
+    var currentGroupId: String? { selectedPet?.groupId }
+
+    var averageWeight: Double? {
+        guard !weightRecords.isEmpty else { return nil }
+        return weightRecords.map(\.weightKg).reduce(0, +) / Double(weightRecords.count)
+    }
+
+    var weightChange: Double? {
+        guard weightRecords.count >= 2, let first = weightRecords.last, let last = weightRecords.first else { return nil }
+        return last.weightKg - first.weightKg
+    }
+
+    // MARK: - Load from cache (synchronous, called on app launch)
+
+    func loadFromCache() {
+        pets = CacheManager.load([PetInfo].self, forKey: CacheManager.petsKey()) ?? []
+        groups = CacheManager.load([PetGroup].self, forKey: CacheManager.groupsKey()) ?? []
+
+        if selectedPet == nil, let first = pets.first {
+            selectedPet = first
+        }
+
+        if let petId = currentPetId {
+            selectedPetDetails = CacheManager.load(PetDetails.self, forKey: CacheManager.petDetailsKey(petId))
+            meals = CacheManager.load([Meal].self, forKey: CacheManager.mealsKey(petId)) ?? []
+            todaySummary = CacheManager.load(TodaySummary.self, forKey: CacheManager.todaySummaryKey(petId))
+            let cached = CacheManager.load(WeightListResponse.self, forKey: CacheManager.weightsKey(petId))
+            weightRecords = cached?.records ?? []
+            weightTotal = cached?.total ?? 0
+            courses = CacheManager.load([TreatmentCourse].self, forKey: CacheManager.coursesKey(petId)) ?? []
+            todaySchedule = CacheManager.load(TodaySchedule.self, forKey: CacheManager.todayScheduleKey(petId))
+        }
+
+        if let groupId = currentGroupId {
+            foods = CacheManager.load([Food].self, forKey: CacheManager.foodsKey(groupId)) ?? []
+            medications = CacheManager.load([Medication].self, forKey: CacheManager.medicationsKey(groupId)) ?? []
+        }
+    }
+
+    // MARK: - Preload all (async, called after login or on app launch)
+
+    @MainActor
+    func preloadAll() async {
+        isPreloading = true
+
+        // Fetch pets first (needed for petId / groupId)
+        await refreshPets()
+
+        guard let petId = currentPetId else {
+            isPreloading = false
+            return
+        }
+
+        let groupId = currentGroupId
+
+        // Fetch everything else in parallel
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { await self.refreshPetDetails(petId: petId) }
+            group.addTask { await self.refreshGroups() }
+            group.addTask { await self.refreshMeals(petId: petId) }
+            group.addTask { await self.refreshTodaySummary(petId: petId) }
+            group.addTask { await self.refreshWeights(petId: petId) }
+            group.addTask { await self.refreshCourses(petId: petId) }
+            group.addTask { await self.refreshTodaySchedule(petId: petId) }
+            if let gid = groupId {
+                group.addTask { await self.refreshFoods(groupId: gid) }
+                group.addTask { await self.refreshMedications(groupId: gid) }
+            }
+        }
+
+        isPreloading = false
+    }
+
+    // MARK: - Switch pet
+
+    @MainActor
+    func switchPet(_ pet: PetInfo) async {
+        selectedPet = pet
+
+        // Load cached data for new pet immediately
+        let petId = pet.id
+        selectedPetDetails = CacheManager.load(PetDetails.self, forKey: CacheManager.petDetailsKey(petId))
+        meals = CacheManager.load([Meal].self, forKey: CacheManager.mealsKey(petId)) ?? []
+        todaySummary = CacheManager.load(TodaySummary.self, forKey: CacheManager.todaySummaryKey(petId))
+        let cached = CacheManager.load(WeightListResponse.self, forKey: CacheManager.weightsKey(petId))
+        weightRecords = cached?.records ?? []
+        weightTotal = cached?.total ?? 0
+        courses = CacheManager.load([TreatmentCourse].self, forKey: CacheManager.coursesKey(petId)) ?? []
+        todaySchedule = CacheManager.load(TodaySchedule.self, forKey: CacheManager.todayScheduleKey(petId))
+
+        if let gid = pet.groupId {
+            foods = CacheManager.load([Food].self, forKey: CacheManager.foodsKey(gid)) ?? []
+            medications = CacheManager.load([Medication].self, forKey: CacheManager.medicationsKey(gid)) ?? []
+        }
+
+        // Background refresh
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { await self.refreshPetDetails(petId: petId) }
+            group.addTask { await self.refreshMeals(petId: petId) }
+            group.addTask { await self.refreshTodaySummary(petId: petId) }
+            group.addTask { await self.refreshWeights(petId: petId) }
+            group.addTask { await self.refreshCourses(petId: petId) }
+            group.addTask { await self.refreshTodaySchedule(petId: petId) }
+            if let gid = pet.groupId {
+                group.addTask { await self.refreshFoods(groupId: gid) }
+                group.addTask { await self.refreshMedications(groupId: gid) }
+            }
+        }
+    }
+
+    // MARK: - Per-domain refresh (fetch API → update memory → write cache)
+
+    @MainActor
+    func refreshPets() async {
+        do {
+            let fetched = try await APIClient.shared.fetchAccessiblePets()
+            pets = fetched
+            CacheManager.save(fetched, forKey: CacheManager.petsKey())
+            if selectedPet == nil, let first = fetched.first {
+                selectedPet = first
+            }
+        } catch {
+            #if DEBUG
+            print("DataStore.refreshPets failed: \(error)")
+            #endif
+        }
+    }
+
+    @MainActor
+    func refreshPetDetails(petId: String) async {
+        do {
+            let details = try await APIClient.shared.fetchPetDetails(petId: petId)
+            selectedPetDetails = details
+            CacheManager.save(details, forKey: CacheManager.petDetailsKey(petId))
+        } catch {
+            #if DEBUG
+            print("DataStore.refreshPetDetails failed: \(error)")
+            #endif
+        }
+    }
+
+    @MainActor
+    func refreshGroups() async {
+        do {
+            let fetched = try await APIClient.shared.fetchMyGroups()
+            groups = fetched
+            CacheManager.save(fetched, forKey: CacheManager.groupsKey())
+        } catch {
+            #if DEBUG
+            print("DataStore.refreshGroups failed: \(error)")
+            #endif
+        }
+    }
+
+    @MainActor
+    func refreshFoods(groupId: String) async {
+        do {
+            let fetched = try await APIClient.shared.fetchFoods(groupId: groupId)
+            foods = fetched
+            CacheManager.save(fetched, forKey: CacheManager.foodsKey(groupId))
+        } catch {
+            #if DEBUG
+            print("DataStore.refreshFoods failed: \(error)")
+            #endif
+        }
+    }
+
+    @MainActor
+    func refreshMeals(petId: String) async {
+        do {
+            let fetched = try await APIClient.shared.fetchMeals(petId: petId)
+            meals = fetched
+            CacheManager.save(fetched, forKey: CacheManager.mealsKey(petId))
+        } catch {
+            #if DEBUG
+            print("DataStore.refreshMeals failed: \(error)")
+            #endif
+        }
+    }
+
+    @MainActor
+    func refreshTodaySummary(petId: String) async {
+        do {
+            let fetched = try await APIClient.shared.fetchTodaySummary(petId: petId)
+            todaySummary = fetched
+            CacheManager.save(fetched, forKey: CacheManager.todaySummaryKey(petId))
+        } catch {
+            #if DEBUG
+            print("DataStore.refreshTodaySummary failed: \(error)")
+            #endif
+        }
+    }
+
+    @MainActor
+    func refreshWeights(petId: String) async {
+        do {
+            let fetched = try await APIClient.shared.fetchWeights(petId: petId, number: 200)
+            weightRecords = fetched.records
+            weightTotal = fetched.total
+            CacheManager.save(fetched, forKey: CacheManager.weightsKey(petId))
+        } catch {
+            #if DEBUG
+            print("DataStore.refreshWeights failed: \(error)")
+            #endif
+        }
+    }
+
+    @MainActor
+    func refreshMedications(groupId: String) async {
+        do {
+            let fetched = try await APIClient.shared.fetchMedications(groupId: groupId)
+            medications = fetched
+            CacheManager.save(fetched, forKey: CacheManager.medicationsKey(groupId))
+        } catch {
+            #if DEBUG
+            print("DataStore.refreshMedications failed: \(error)")
+            #endif
+        }
+    }
+
+    @MainActor
+    func refreshCourses(petId: String) async {
+        do {
+            let fetched = try await APIClient.shared.fetchCourses(petId: petId)
+            courses = fetched
+            CacheManager.save(fetched, forKey: CacheManager.coursesKey(petId))
+        } catch {
+            #if DEBUG
+            print("DataStore.refreshCourses failed: \(error)")
+            #endif
+        }
+    }
+
+    @MainActor
+    func refreshTodaySchedule(petId: String) async {
+        do {
+            let fetched = try await APIClient.shared.fetchTodaySchedule(petId: petId)
+            todaySchedule = fetched
+            CacheManager.save(fetched, forKey: CacheManager.todayScheduleKey(petId))
+        } catch {
+            #if DEBUG
+            print("DataStore.refreshTodaySchedule failed: \(error)")
+            #endif
+        }
+    }
+
+    // MARK: - Clear (on logout)
+
+    func clearAll() {
+        pets = []
+        selectedPet = nil
+        selectedPetDetails = nil
+        groups = []
+        foods = []
+        meals = []
+        todaySummary = nil
+        weightRecords = []
+        weightTotal = 0
+        medications = []
+        courses = []
+        todaySchedule = nil
+        CacheManager.clearAll()
+    }
+}

--- a/ios/PetCare/PetCare/Views/Dashboard/DashboardPageView.swift
+++ b/ios/PetCare/PetCare/Views/Dashboard/DashboardPageView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct DashboardPageView: View {
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
 
     var body: some View {
         NavigationStack {
@@ -10,13 +10,13 @@ struct DashboardPageView: View {
 
                 ScrollView {
                     VStack(spacing: 16) {
-                        HeaderView(title: "Dashboard", petSelector: petSelector) {
-                            await petSelector.refresh()
+                        HeaderView(title: "Dashboard", dataStore: dataStore) {
+                            await dataStore.refreshPets()
                         }
 
-                        if let pet = petSelector.selectedPet {
-                            PetSummaryCard(pet: pet, details: petSelector.selectedPetDetails)
-                            QuickStatsGrid(details: petSelector.selectedPetDetails)
+                        if let pet = dataStore.selectedPet {
+                            PetSummaryCard(pet: pet, details: dataStore.selectedPetDetails)
+                            QuickStatsGrid(details: dataStore.selectedPetDetails)
                         } else {
                             emptyState
                         }

--- a/ios/PetCare/PetCare/Views/Food/FoodPageView.swift
+++ b/ios/PetCare/PetCare/Views/Food/FoodPageView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct FoodPageView: View {
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     @State private var foodVM = FoodViewModel()
     @State private var showCreateFood = false
 
@@ -41,14 +41,14 @@ struct FoodPageView: View {
                 }
             }
             .sheet(isPresented: $showCreateFood) {
-                CreateFoodSheet(petSelector: petSelector, foodVM: foodVM)
+                CreateFoodSheet(dataStore: dataStore, foodVM: foodVM)
             }
-            .onChange(of: petSelector.selectedPet?.groupId) { _, newGid in
+            .onChange(of: dataStore.currentGroupId) { _, newGid in
                 guard let gid = newGid else { return }
                 Task { await foodVM.loadFoods(groupId: gid) }
             }
             .task {
-                if let gid = petSelector.selectedPet?.groupId { await foodVM.loadFoods(groupId: gid) }
+                if let gid = dataStore.currentGroupId { await foodVM.loadFoods(groupId: gid) }
             }
         }
     }
@@ -96,7 +96,7 @@ struct FoodCard: View {
 }
 
 struct CreateFoodSheet: View {
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     var foodVM: FoodViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var brand = ""
@@ -140,7 +140,7 @@ struct CreateFoodSheet: View {
     }
 
     private func save() {
-        guard let gid = petSelector.selectedPet?.groupId else { return }
+        guard let gid = dataStore.currentGroupId else { return }
         isCreating = true
         Task {
             let request = CreateFoodRequest(

--- a/ios/PetCare/PetCare/Views/HeaderView.swift
+++ b/ios/PetCare/PetCare/Views/HeaderView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct HeaderView: View {
     let title: String
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     var onRefresh: (() async -> Void)?
     @State private var showPetPicker = false
     @State private var isRefreshing = false
@@ -30,10 +30,10 @@ struct HeaderView: View {
                 }
             }
 
-            if petSelector.pets.count > 1 {
+            if dataStore.pets.count > 1 {
                 Button { showPetPicker = true } label: {
                     HStack(spacing: 4) {
-                        Text(petSelector.selectedPet?.name ?? "Select Pet")
+                        Text(dataStore.selectedPet?.name ?? "Select Pet")
                             .font(.subheadline).fontWeight(.medium)
                             .lineLimit(1)
                             .foregroundStyle(Color.textPrimary)
@@ -47,7 +47,7 @@ struct HeaderView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 8))
                 }
                 .sheet(isPresented: $showPetPicker) {
-                    PetPickerSheet(petSelector: petSelector, isPresented: $showPetPicker)
+                    PetPickerSheet(dataStore: dataStore, isPresented: $showPetPicker)
                         .presentationDetents([.medium])
                 }
             }
@@ -59,14 +59,14 @@ struct HeaderView: View {
 }
 
 struct PetPickerSheet: View {
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     @Binding var isPresented: Bool
 
     var body: some View {
         NavigationStack {
-            List(petSelector.pets) { pet in
+            List(dataStore.pets) { pet in
                 Button {
-                    petSelector.selectPet(pet)
+                    Task { await dataStore.switchPet(pet) }
                     isPresented = false
                 } label: {
                     HStack {
@@ -95,7 +95,7 @@ struct PetPickerSheet: View {
                             }
                         }
                         Spacer()
-                        if pet.id == petSelector.selectedPet?.id {
+                        if pet.id == dataStore.selectedPet?.id {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(Color.accentPink)
                         }

--- a/ios/PetCare/PetCare/Views/MainTabView.swift
+++ b/ios/PetCare/PetCare/Views/MainTabView.swift
@@ -2,40 +2,40 @@ import SwiftUI
 
 struct MainTabView: View {
     var authViewModel: AuthViewModel
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     @State private var selectedTab = 0
 
     var body: some View {
         TabView(selection: $selectedTab) {
-            DashboardPageView(petSelector: petSelector)
+            DashboardPageView(dataStore: dataStore)
                 .tabItem {
                     Image(systemName: "chart.bar.fill")
                     Text("Dashboard")
                 }
                 .tag(0)
 
-            MealPageView(petSelector: petSelector)
+            MealPageView(dataStore: dataStore)
                 .tabItem {
                     Image(systemName: "fork.knife")
                     Text("Meals")
                 }
                 .tag(1)
 
-            MedicinePageView(petSelector: petSelector)
+            MedicinePageView(dataStore: dataStore)
                 .tabItem {
                     Image(systemName: "pills.fill")
                     Text("Medicine")
                 }
                 .tag(2)
 
-            WeightPageView(petSelector: petSelector)
+            WeightPageView(dataStore: dataStore)
                 .tabItem {
                     Image(systemName: "scalemass.fill")
                     Text("Weight")
                 }
                 .tag(3)
 
-            SettingsPageView(authViewModel: authViewModel, petSelector: petSelector)
+            SettingsPageView(authViewModel: authViewModel, dataStore: dataStore)
                 .tabItem {
                     Image(systemName: "gearshape.fill")
                     Text("Settings")

--- a/ios/PetCare/PetCare/Views/Meal/MealPageView.swift
+++ b/ios/PetCare/PetCare/Views/Meal/MealPageView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import Charts
 
 struct MealPageView: View {
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     @State private var mealVM = MealViewModel()
     @State private var foodVM = FoodViewModel()
     @State private var showCreateMeal = false
@@ -14,13 +14,13 @@ struct MealPageView: View {
 
                 ScrollView {
                     VStack(spacing: 16) {
-                        HeaderView(title: "Meals", petSelector: petSelector) {
-                            if let pet = petSelector.selectedPet {
+                        HeaderView(title: "Meals", dataStore: dataStore) {
+                            if let pet = dataStore.selectedPet {
                                 await mealVM.refresh(petId: pet.id)
                             }
                         }
 
-                        if let pet = petSelector.selectedPet {
+                        if let pet = dataStore.selectedPet {
                             // Today's summary
                             if let summary = mealVM.todaySummary {
                                 TodaySummaryCard(summary: summary, calorieTarget: pet.dailyCalorieTarget)
@@ -62,21 +62,21 @@ struct MealPageView: View {
             }
             .navigationBarHidden(true)
             .sheet(isPresented: $showCreateMeal) {
-                CreateMealSheet(petSelector: petSelector, foodVM: foodVM) {
-                    if let pet = petSelector.selectedPet {
+                CreateMealSheet(dataStore: dataStore, foodVM: foodVM) {
+                    if let pet = dataStore.selectedPet {
                         Task { await mealVM.refresh(petId: pet.id) }
                     }
                 }
             }
-            .onChange(of: petSelector.selectedPet?.id) { _, newId in
+            .onChange(of: dataStore.selectedPet?.id) { _, newId in
                 guard let petId = newId else { return }
                 Task {
                     await mealVM.refresh(petId: petId)
-                    if let gid = petSelector.selectedPet?.groupId { await foodVM.loadFoods(groupId: gid) }
+                    if let gid = dataStore.currentGroupId { await foodVM.loadFoods(groupId: gid) }
                 }
             }
             .task {
-                if let pet = petSelector.selectedPet {
+                if let pet = dataStore.selectedPet {
                     await mealVM.refresh(petId: pet.id)
                     if let gid = pet.groupId { await foodVM.loadFoods(groupId: gid) }
                 }
@@ -237,7 +237,7 @@ struct MealRow: View {
 // MARK: - Create Meal Sheet
 
 struct CreateMealSheet: View {
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     var foodVM: FoodViewModel
     var onCreated: () -> Void
     @Environment(\.dismiss) private var dismiss
@@ -294,7 +294,7 @@ struct CreateMealSheet: View {
     }
 
     private func createMeal() {
-        guard let petId = petSelector.selectedPet?.id, let foodId = selectedFoodId else { return }
+        guard let petId = dataStore.selectedPet?.id, let foodId = selectedFoodId else { return }
         isCreating = true
         Task {
             do {

--- a/ios/PetCare/PetCare/Views/Medicine/MedicinePageView.swift
+++ b/ios/PetCare/PetCare/Views/Medicine/MedicinePageView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct MedicinePageView: View {
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     @State private var medicineVM = MedicineViewModel()
     @State private var showCreateMedication = false
     @State private var showCreateCourse = false
@@ -13,13 +13,13 @@ struct MedicinePageView: View {
 
                 ScrollView {
                     VStack(spacing: 16) {
-                        HeaderView(title: "Medicine", petSelector: petSelector) {
-                            if let pet = petSelector.selectedPet, let gid = pet.groupId {
+                        HeaderView(title: "Medicine", dataStore: dataStore) {
+                            if let pet = dataStore.selectedPet, let gid = pet.groupId {
                                 await medicineVM.refresh(petId: pet.id, groupId: gid)
                             }
                         }
 
-                        if let pet = petSelector.selectedPet {
+                        if let pet = dataStore.selectedPet {
                             TodayChecklistSection(schedule: medicineVM.todaySchedule, medicineVM: medicineVM, petId: pet.id)
                             ActiveCoursesSection(courses: medicineVM.courses, medicineVM: medicineVM, petId: pet.id, onAddCourse: { showCreateCourse = true })
                             MedicationDatabaseSection(medications: medicineVM.medications, onAdd: { showCreateMedication = true })
@@ -33,18 +33,18 @@ struct MedicinePageView: View {
             }
             .navigationBarHidden(true)
             .sheet(isPresented: $showCreateMedication) {
-                CreateMedicationSheet(petSelector: petSelector, medicineVM: medicineVM)
+                CreateMedicationSheet(dataStore: dataStore, medicineVM: medicineVM)
             }
             .sheet(isPresented: $showCreateCourse) {
-                CreateCourseSheet(petSelector: petSelector, medicineVM: medicineVM)
+                CreateCourseSheet(dataStore: dataStore, medicineVM: medicineVM)
             }
-            .onChange(of: petSelector.selectedPet?.id) { _, _ in loadAll() }
+            .onChange(of: dataStore.selectedPet?.id) { _, _ in loadAll() }
             .task { loadAll() }
         }
     }
 
     private func loadAll() {
-        guard let pet = petSelector.selectedPet, let gid = pet.groupId else { return }
+        guard let pet = dataStore.selectedPet, let gid = pet.groupId else { return }
         Task { await medicineVM.refresh(petId: pet.id, groupId: gid) }
     }
 }
@@ -261,7 +261,7 @@ struct MedicationDatabaseSection: View {
 // MARK: - Create Sheets
 
 struct CreateMedicationSheet: View {
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     var medicineVM: MedicineViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var name = ""
@@ -281,7 +281,7 @@ struct CreateMedicationSheet: View {
                 ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
-                        guard let gid = petSelector.selectedPet?.groupId else { return }
+                        guard let gid = dataStore.currentGroupId else { return }
                         Task { try? await medicineVM.createMedication(name: name, groupId: gid); dismiss() }
                     }
                     .disabled(name.isEmpty)
@@ -292,7 +292,7 @@ struct CreateMedicationSheet: View {
 }
 
 struct CreateCourseSheet: View {
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     var medicineVM: MedicineViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var selectedMedId: String?
@@ -325,7 +325,7 @@ struct CreateCourseSheet: View {
                 ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
-                        guard let petId = petSelector.selectedPet?.id, let medId = selectedMedId else { return }
+                        guard let petId = dataStore.selectedPet?.id, let medId = selectedMedId else { return }
                         Task {
                             let req = CreateCourseRequest(
                                 petId: petId, medicationId: medId,

--- a/ios/PetCare/PetCare/Views/Settings/SettingsPageView.swift
+++ b/ios/PetCare/PetCare/Views/Settings/SettingsPageView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct SettingsPageView: View {
     var authViewModel: AuthViewModel
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     @State private var groupVM = GroupViewModel()
     @State private var petVM = PetViewModel()
     @State private var showCreatePet = false
@@ -16,7 +16,7 @@ struct SettingsPageView: View {
 
                 ScrollView {
                     VStack(spacing: 16) {
-                        HeaderView(title: "Settings", petSelector: petSelector)
+                        HeaderView(title: "Settings", dataStore: dataStore)
 
                         // User profile
                         if let user = authViewModel.user {
@@ -24,7 +24,7 @@ struct SettingsPageView: View {
                         }
 
                         // My Pets
-                        MyPetsSection(pets: petSelector.pets, onCreatePet: { showCreatePet = true })
+                        MyPetsSection(pets: dataStore.pets, onCreatePet: { showCreatePet = true })
 
                         // Groups
                         GroupsSection(groupVM: groupVM, onCreateGroup: { showCreateGroup = true }, onJoinGroup: { showJoinGroup = true })
@@ -50,7 +50,7 @@ struct SettingsPageView: View {
             }
             .navigationBarHidden(true)
             .sheet(isPresented: $showCreatePet) {
-                CreatePetSheet(petSelector: petSelector)
+                CreatePetSheet(dataStore: dataStore)
             }
             .sheet(isPresented: $showCreateGroup) {
                 CreateGroupSheet(groupVM: groupVM)
@@ -228,7 +228,7 @@ struct GroupRow: View {
 // MARK: - Create / Join Sheets
 
 struct CreatePetSheet: View {
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     @Environment(\.dismiss) private var dismiss
     @State private var name = ""
     @State private var petType: PetType = .dog
@@ -257,7 +257,7 @@ struct CreatePetSheet: View {
                         Task {
                             let req = CreatePetRequest(name: name, petType: petType, breed: breed.isEmpty ? nil : breed, gender: nil, birthDate: nil, currentWeightKg: nil, targetWeightKg: nil, dailyCalorieTarget: nil, notes: nil)
                             _ = try? await APIClient.shared.createPet(req)
-                            await petSelector.loadPets()
+                            await dataStore.refreshPets()
                             dismiss()
                         }
                     }

--- a/ios/PetCare/PetCare/Views/Weight/WeightPageView.swift
+++ b/ios/PetCare/PetCare/Views/Weight/WeightPageView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import Charts
 
 struct WeightPageView: View {
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     @State private var weightVM = WeightViewModel()
     @State private var showCreateWeight = false
 
@@ -13,11 +13,11 @@ struct WeightPageView: View {
 
                 ScrollView {
                     VStack(spacing: 16) {
-                        HeaderView(title: "Weight", petSelector: petSelector) {
-                            if let pet = petSelector.selectedPet { await weightVM.loadRecords(petId: pet.id) }
+                        HeaderView(title: "Weight", dataStore: dataStore) {
+                            if let pet = dataStore.selectedPet { await weightVM.loadRecords(petId: pet.id) }
                         }
 
-                        if petSelector.selectedPet != nil {
+                        if dataStore.selectedPet != nil {
                             if !weightVM.records.isEmpty {
                                 WeightChartCard(records: weightVM.records)
                                 WeightStatsRow(vm: weightVM)
@@ -50,18 +50,18 @@ struct WeightPageView: View {
             }
             .navigationBarHidden(true)
             .sheet(isPresented: $showCreateWeight) {
-                CreateWeightSheet(petSelector: petSelector) {
-                    if let pet = petSelector.selectedPet {
+                CreateWeightSheet(dataStore: dataStore) {
+                    if let pet = dataStore.selectedPet {
                         Task { await weightVM.loadRecords(petId: pet.id) }
                     }
                 }
             }
-            .onChange(of: petSelector.selectedPet?.id) { _, newId in
+            .onChange(of: dataStore.selectedPet?.id) { _, newId in
                 guard let petId = newId else { return }
                 Task { await weightVM.loadRecords(petId: petId) }
             }
             .task {
-                if let pet = petSelector.selectedPet { await weightVM.loadRecords(petId: pet.id) }
+                if let pet = dataStore.selectedPet { await weightVM.loadRecords(petId: pet.id) }
             }
         }
     }
@@ -179,7 +179,7 @@ struct WeightRecordsList: View {
 }
 
 struct CreateWeightSheet: View {
-    var petSelector: PetSelectorViewModel
+    var dataStore: DataStore
     var onCreated: () -> Void
     @Environment(\.dismiss) private var dismiss
     @State private var weightStr = ""
@@ -217,7 +217,7 @@ struct CreateWeightSheet: View {
     }
 
     private func save() {
-        guard let petId = petSelector.selectedPet?.id, let weight = Double(weightStr) else { return }
+        guard let petId = dataStore.selectedPet?.id, let weight = Double(weightStr) else { return }
         isCreating = true
         Task {
             do {


### PR DESCRIPTION
Closes #113

## Summary
- Add CacheManager (UserDefaults JSON cache with 5-min stale threshold)
- Add DataStore (@Observable singleton) as centralized data hub for all domains
- App launch: load cache synchronously (instant) → background API refresh
- All views now read from DataStore instead of individual ViewModels hitting API

## Files changed by layer
- **Services**: New `CacheManager.swift` — save/load/clear with timestamp expiry
- **ViewModels**: New `DataStore.swift` — holds pets, foods, meals, weights, medicine, groups; preloadAll(), switchPet(), clearAll()
- **Views**: `ContentView.swift` — cache load + background preload. `MainTabView`, `HeaderView`, all 6 page views — accept DataStore instead of PetSelectorViewModel

## Manual test plan (Xcode simulator)
1. Login → launch animation → tabs show data (preloaded during launch)
2. Kill app (swipe up) → reopen → data appears instantly from cache (no spinner)
3. Switch between all 5 tabs rapidly — data already there, no loading
4. Switch pets via selector → all tabs update
5. Logout → login again → fresh data loaded

## New files to add to Xcode project
- `ios/PetCare/PetCare/Services/CacheManager.swift`
- `ios/PetCare/PetCare/ViewModels/DataStore.swift`
- (right-click in Xcode → Add Files to "PetCare")

## Notes
- PetSelectorViewModel is now unused — can be removed in a follow-up cleanup
- Individual domain ViewModels (MealViewModel, WeightViewModel, etc.) still exist but page views now pass DataStore; #114 will fully integrate the stale-while-revalidate pattern per-tab
- Cache uses UserDefaults — suitable for < 1000 records per domain