### PR TITLE
[#122 #123] Add metrics infrastructure and /metrics endpoint

### DIFF
--- a/backend/core/cloudinary_client.py
+++ b/backend/core/cloudinary_client.py
@@ -20,13 +20,17 @@ message. This keeps unit tests and local imports working without env vars
 while still failing loudly the moment a real upload is attempted.
 """
 
+import logging
 import os
+import time
 from typing import Any, Dict
 
 import cloudinary
 import cloudinary.uploader
 from fastapi import HTTPException, status
 from starlette.concurrency import run_in_threadpool
+
+logger = logging.getLogger(__name__)
 
 
 def _configure_cloudinary() -> None:
@@ -90,6 +94,7 @@ async def upload_image(
             resource_type="image",
         )
 
+    start = time.perf_counter()
     try:
         result = await run_in_threadpool(_do_upload)
     except Exception as exc:
@@ -97,6 +102,14 @@ async def upload_image(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Cloudinary upload failed: {exc}",
         )
+    finally:
+        duration_ms = (time.perf_counter() - start) * 1000.0
+        try:
+            from backend.core.metrics import metrics_collector
+
+            metrics_collector.record_external_call("cloudinary", duration_ms)
+        except Exception:
+            pass
 
     return {
         "secure_url": result["secure_url"],

--- a/backend/core/metrics.py
+++ b/backend/core/metrics.py
@@ -21,10 +21,9 @@ Usage::
 
 import logging
 import threading
-import time
 from collections import defaultdict, deque
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 

--- a/backend/core/metrics.py
+++ b/backend/core/metrics.py
@@ -1,0 +1,184 @@
+"""
+In-memory metrics collector for API performance monitoring.
+
+Collects request timing, DB query timing, and external call timing using
+thread-safe deques. Each metric category stores the most recent N entries
+(configurable via ``maxlen``, default 500). Percentile computation is
+on-demand — no background threads.
+
+Usage::
+
+    from backend.core.metrics import metrics_collector
+
+    # Record a timing
+    metrics_collector.record_request("GET", "/user/me", 200, 12.3)
+    metrics_collector.record_db_query("read_one", 3.2)
+    metrics_collector.record_external_call("cloudinary", 1200.5)
+
+    # Read stats
+    stats = metrics_collector.get_request_stats()
+"""
+
+import logging
+import threading
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Slow-request thresholds (ms)
+SLOW_REQUEST_THRESHOLD_MS = 1000.0
+SLOW_DB_QUERY_THRESHOLD_MS = 500.0
+SLOW_EXTERNAL_CALL_THRESHOLD_MS = 5000.0
+
+DEFAULT_MAXLEN = 500
+
+
+@dataclass
+class SlowRequestEntry:
+    method: str
+    path: str
+    duration_ms: float
+    timestamp: str
+
+
+def _percentile(sorted_data: List[float], p: float) -> float:
+    """Compute the p-th percentile from a pre-sorted list."""
+    if not sorted_data:
+        return 0.0
+    k = (len(sorted_data) - 1) * (p / 100.0)
+    f = int(k)
+    c = f + 1
+    if c >= len(sorted_data):
+        return sorted_data[f]
+    return sorted_data[f] + (k - f) * (sorted_data[c] - sorted_data[f])
+
+
+class MetricsCollector:
+    """Thread-safe in-memory metrics collector."""
+
+    def __init__(self, maxlen: int = DEFAULT_MAXLEN):
+        self._maxlen = maxlen
+        self._lock = threading.Lock()
+
+        # request timings: key = (method, path) -> deque of durations (ms)
+        self._requests: Dict[tuple, deque] = defaultdict(lambda: deque(maxlen=self._maxlen))
+
+        # DB query timings: key = operation name -> deque of durations (ms)
+        self._db_queries: Dict[str, deque] = defaultdict(lambda: deque(maxlen=self._maxlen))
+
+        # External call timings: key = service name -> deque of durations (ms)
+        self._external_calls: Dict[str, deque] = defaultdict(lambda: deque(maxlen=self._maxlen))
+
+        # Slow requests log (capped)
+        self._slow_requests: deque = deque(maxlen=self._maxlen)
+
+    def record_request(self, method: str, path: str, status_code: int, duration_ms: float) -> None:
+        with self._lock:
+            self._requests[(method, path)].append(duration_ms)
+            if duration_ms >= SLOW_REQUEST_THRESHOLD_MS:
+                from datetime import datetime, timezone
+
+                self._slow_requests.append(
+                    SlowRequestEntry(
+                        method=method,
+                        path=path,
+                        duration_ms=round(duration_ms, 2),
+                        timestamp=datetime.now(timezone.utc).isoformat(),
+                    )
+                )
+                logger.warning(
+                    "SLOW REQUEST: %s %s %d %.1fms (threshold: %.0fms)",
+                    method,
+                    path,
+                    status_code,
+                    duration_ms,
+                    SLOW_REQUEST_THRESHOLD_MS,
+                )
+
+    def record_db_query(self, operation: str, duration_ms: float) -> None:
+        with self._lock:
+            self._db_queries[operation].append(duration_ms)
+        if duration_ms >= SLOW_DB_QUERY_THRESHOLD_MS:
+            logger.warning(
+                "SLOW QUERY: %s %.1fms (threshold: %.0fms)",
+                operation,
+                duration_ms,
+                SLOW_DB_QUERY_THRESHOLD_MS,
+            )
+
+    def record_external_call(self, service: str, duration_ms: float) -> None:
+        with self._lock:
+            self._external_calls[service].append(duration_ms)
+        if duration_ms >= SLOW_EXTERNAL_CALL_THRESHOLD_MS:
+            logger.warning(
+                "SLOW EXTERNAL CALL: %s %.1fms (threshold: %.0fms)",
+                service,
+                duration_ms,
+                SLOW_EXTERNAL_CALL_THRESHOLD_MS,
+            )
+
+    def _compute_stats(self, timings: deque) -> Dict[str, Any]:
+        data = list(timings)
+        if not data:
+            return {"count": 0, "avg_ms": 0.0, "p50_ms": 0.0, "p95_ms": 0.0, "max_ms": 0.0}
+        sorted_data = sorted(data)
+        return {
+            "count": len(data),
+            "avg_ms": round(sum(data) / len(data), 2),
+            "p50_ms": round(_percentile(sorted_data, 50), 2),
+            "p95_ms": round(_percentile(sorted_data, 95), 2),
+            "max_ms": round(max(data), 2),
+        }
+
+    def get_request_stats(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            items = list(self._requests.items())
+        results = []
+        for (method, path), timings in items:
+            stats = self._compute_stats(timings)
+            stats["method"] = method
+            stats["path"] = path
+            results.append(stats)
+        results.sort(key=lambda x: x["p95_ms"], reverse=True)
+        return results
+
+    def get_db_query_stats(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            items = list(self._db_queries.items())
+        results = []
+        for operation, timings in items:
+            stats = self._compute_stats(timings)
+            stats["operation"] = operation
+            results.append(stats)
+        results.sort(key=lambda x: x["p95_ms"], reverse=True)
+        return results
+
+    def get_external_call_stats(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            items = list(self._external_calls.items())
+        results = []
+        for service, timings in items:
+            stats = self._compute_stats(timings)
+            stats["service"] = service
+            results.append(stats)
+        results.sort(key=lambda x: x["p95_ms"], reverse=True)
+        return results
+
+    def get_slow_requests(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [
+                {
+                    "method": entry.method,
+                    "path": entry.path,
+                    "duration_ms": entry.duration_ms,
+                    "timestamp": entry.timestamp,
+                }
+                for entry in self._slow_requests
+            ]
+
+
+# Module-level singleton
+metrics_collector = MetricsCollector()

--- a/backend/core/postgres_database.py
+++ b/backend/core/postgres_database.py
@@ -1,4 +1,6 @@
+import logging
 import os
+import time
 from contextlib import asynccontextmanager
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
@@ -6,6 +8,8 @@ from typing import Any, Dict, List, Optional
 import asyncpg
 from asyncpg import Pool
 from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
 
 # Load environment variables
 load_dotenv("backend/.env")
@@ -108,6 +112,16 @@ class PostgresAsyncClient:
         else:
             return obj
 
+    # ================== Timing Helper ==================
+
+    def _record_query_timing(self, operation: str, duration_ms: float) -> None:
+        try:
+            from backend.core.metrics import metrics_collector
+
+            metrics_collector.record_db_query(operation, duration_ms)
+        except Exception:
+            pass
+
     # ================== Simple Query Methods ==================
 
     async def read(self, query: str, *args: Any) -> List[Dict[str, Any]]:
@@ -121,6 +135,7 @@ class PostgresAsyncClient:
         Returns:
             List[Dict[str, Any]]: Query results as list of dictionaries with Decimal values converted to float
         """
+        start = time.perf_counter()
         try:
             async with self.get_connection() as conn:
                 rows = await conn.fetch(query, *args)
@@ -128,6 +143,8 @@ class PostgresAsyncClient:
                 return self._convert_decimals_to_floats(result)
         except Exception as e:
             raise e
+        finally:
+            self._record_query_timing("read", (time.perf_counter() - start) * 1000.0)
 
     async def read_one(self, query: str, *args: Any) -> Optional[Dict[str, Any]]:
         """
@@ -142,6 +159,7 @@ class PostgresAsyncClient:
                 First query result as dictionary with Decimal values converted to float,
                 or None if no result
         """
+        start = time.perf_counter()
         try:
             async with self.get_connection() as conn:
                 row = await conn.fetchrow(query, *args)
@@ -152,6 +170,8 @@ class PostgresAsyncClient:
 
         except Exception as e:
             raise e
+        finally:
+            self._record_query_timing("read_one", (time.perf_counter() - start) * 1000.0)
 
     async def insert_one(self, table: str, data: Dict[str, Any]) -> Any:
         """
@@ -164,6 +184,7 @@ class PostgresAsyncClient:
         Returns:
             Any: The ID of the inserted record (if table has 'id' column), or the full inserted record
         """
+        start = time.perf_counter()
         try:
             # Convert timestamp fields automatically
 
@@ -190,6 +211,8 @@ class PostgresAsyncClient:
 
         except Exception as e:
             raise e
+        finally:
+            self._record_query_timing("insert_one", (time.perf_counter() - start) * 1000.0)
 
     async def insert(self, table: str, data: List[Dict[str, Any]]) -> List[Any]:
         """
@@ -202,6 +225,7 @@ class PostgresAsyncClient:
         Returns:
             List[Any]: List of inserted record IDs (if table has 'id' column), or list of full inserted records
         """
+        start = time.perf_counter()
         try:
             if not data:
                 return []
@@ -252,6 +276,8 @@ class PostgresAsyncClient:
 
         except Exception as e:
             raise e
+        finally:
+            self._record_query_timing("insert", (time.perf_counter() - start) * 1000.0)
 
     async def execute(self, query: str, *args: Any) -> str:
         """
@@ -264,9 +290,13 @@ class PostgresAsyncClient:
         Returns:
             str: Result status from the database (e.g., "INSERT 0 1", "UPDATE 1", "DELETE 1")
         """
-        async with self.get_connection() as conn:
-            result = await conn.execute(query, *args)
-            return result
+        start = time.perf_counter()
+        try:
+            async with self.get_connection() as conn:
+                result = await conn.execute(query, *args)
+                return result
+        finally:
+            self._record_query_timing("execute", (time.perf_counter() - start) * 1000.0)
 
     async def execute_returning(self, query: str, *args: Any) -> Any:
         """
@@ -279,9 +309,13 @@ class PostgresAsyncClient:
         Returns:
             Any: The returned value from the RETURNING clause with Decimal values converted to float
         """
-        async with self.get_connection() as conn:
-            result = await conn.fetchrow(query, *args)
-            if result:
-                result_dict = dict(result)
-                return self._convert_decimals_to_floats(result_dict)
-            return None
+        start = time.perf_counter()
+        try:
+            async with self.get_connection() as conn:
+                result = await conn.fetchrow(query, *args)
+                if result:
+                    result_dict = dict(result)
+                    return self._convert_decimals_to_floats(result_dict)
+                return None
+        finally:
+            self._record_query_timing("execute_returning", (time.perf_counter() - start) * 1000.0)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,13 +1,16 @@
 import logging
+import time
 from contextlib import asynccontextmanager
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from scalar_fastapi import get_scalar_api_reference
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from backend.core.db_manager import close_database, init_database
 from backend.core.environment import env_config, get_config
+from backend.core.metrics import metrics_collector
 from backend.routers.auth_router import router as auth_router
 from backend.routers.food_router import router as food_router
 from backend.routers.group_router import router as group_router
@@ -21,6 +24,22 @@ logging.basicConfig(
     level=getattr(logging, get_config("log_level")), format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+
+class TimingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration_ms = (time.perf_counter() - start) * 1000.0
+
+        method = request.method
+        path = request.url.path
+        status_code = response.status_code
+
+        logger.info("%s %s %d %.1fms", method, path, status_code, duration_ms)
+        metrics_collector.record_request(method, path, status_code, duration_ms)
+
+        return response
 
 
 @asynccontextmanager
@@ -68,6 +87,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.add_middleware(TimingMiddleware)
 
 app.include_router(auth_router)
 app.include_router(user_router)

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ from backend.routers.food_router import router as food_router
 from backend.routers.group_router import router as group_router
 from backend.routers.meal_router import router as meal_router
 from backend.routers.medicine_router import router as medicine_router
+from backend.routers.metrics_router import router as metrics_router
 from backend.routers.pet_router import router as pet_router
 from backend.routers.user_router import router as user_router
 from backend.routers.weight_router import router as weight_router
@@ -98,6 +99,7 @@ app.include_router(food_router)
 app.include_router(meal_router)
 app.include_router(weight_router)
 app.include_router(medicine_router)
+app.include_router(metrics_router)
 
 
 # Add Scalar API documentation

--- a/backend/models/metrics.py
+++ b/backend/models/metrics.py
@@ -1,0 +1,45 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class EndpointStats(BaseModel):
+    method: str
+    path: str
+    count: int
+    avg_ms: float
+    p50_ms: float
+    p95_ms: float
+    max_ms: float
+
+
+class DbQueryStats(BaseModel):
+    operation: str
+    count: int
+    avg_ms: float
+    p50_ms: float
+    p95_ms: float
+    max_ms: float
+
+
+class ExternalCallStats(BaseModel):
+    service: str
+    count: int
+    avg_ms: float
+    p50_ms: float
+    p95_ms: float
+    max_ms: float
+
+
+class SlowRequestEntry(BaseModel):
+    method: str
+    path: str
+    duration_ms: float
+    timestamp: str
+
+
+class MetricsData(BaseModel):
+    endpoints: List[EndpointStats]
+    db_queries: List[DbQueryStats]
+    external_calls: List[ExternalCallStats]
+    slow_requests: List[SlowRequestEntry]

--- a/backend/routers/metrics_router.py
+++ b/backend/routers/metrics_router.py
@@ -1,0 +1,23 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from backend.core.metrics import metrics_collector
+from backend.models.user import UserInfo
+from backend.services.auth_service import get_current_user
+
+router = APIRouter(prefix="/metrics", tags=["metrics"])
+
+
+@router.get("")
+async def get_metrics(current_user: Annotated[UserInfo, Depends(get_current_user)]) -> dict:
+    return {
+        "status": 1,
+        "data": {
+            "endpoints": metrics_collector.get_request_stats(),
+            "db_queries": metrics_collector.get_db_query_stats(),
+            "external_calls": metrics_collector.get_external_call_stats(),
+            "slow_requests": metrics_collector.get_slow_requests(),
+        },
+        "message": "ok",
+    }

--- a/backend/services/google_auth_provider.py
+++ b/backend/services/google_auth_provider.py
@@ -1,10 +1,14 @@
+import logging
 import os
+import time
 
 import httpx
 from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token
 
 from backend.models.auth import GoogleUserInfo
+
+logger = logging.getLogger(__name__)
 
 
 class GoogleAuthProvider:
@@ -16,6 +20,14 @@ class GoogleAuthProvider:
         self.allowed_client_ids = [client_id]
         if ios_client_id:
             self.allowed_client_ids.append(ios_client_id)
+
+    def _record_external_timing(self, service: str, duration_ms: float) -> None:
+        try:
+            from backend.core.metrics import metrics_collector
+
+            metrics_collector.record_external_call(service, duration_ms)
+        except Exception:
+            pass
 
     async def exchange_code_for_tokens(self, authorization_code: str, redirect_uri: str) -> dict:
         """Exchange authorization code for access token and ID token"""
@@ -29,21 +41,29 @@ class GoogleAuthProvider:
             "redirect_uri": redirect_uri,
         }
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(token_url, data=data)
-            response.raise_for_status()
-            return response.json()
+        start = time.perf_counter()
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(token_url, data=data)
+                response.raise_for_status()
+                return response.json()
+        finally:
+            self._record_external_timing("google_oauth_exchange", (time.perf_counter() - start) * 1000.0)
 
     async def verify_token(self, token: str) -> GoogleUserInfo:
         # Try each allowed client ID (web, iOS, etc.)
+        start = time.perf_counter()
         last_error = None
-        for cid in self.allowed_client_ids:
-            try:
-                id_info = id_token.verify_oauth2_token(token, google_requests.Request(), cid)
-                return GoogleUserInfo(
-                    id=id_info["sub"], email=id_info["email"], name=id_info["name"], picture=id_info["picture"]
-                )
-            except Exception as e:
-                last_error = e
-                continue
-        raise last_error
+        try:
+            for cid in self.allowed_client_ids:
+                try:
+                    id_info = id_token.verify_oauth2_token(token, google_requests.Request(), cid)
+                    return GoogleUserInfo(
+                        id=id_info["sub"], email=id_info["email"], name=id_info["name"], picture=id_info["picture"]
+                    )
+                except Exception as e:
+                    last_error = e
+                    continue
+            raise last_error
+        finally:
+            self._record_external_timing("google_oauth_verify", (time.perf_counter() - start) * 1000.0)


### PR DESCRIPTION
Closes #122
Closes #123

## Summary
- Add `MetricsCollector` singleton class for in-memory performance metrics collection (deque maxlen=500, thread-safe)
- Add `TimingMiddleware` (Starlette) that logs and records every request's method/path/status/duration
- Instrument all 6 `PostgresAsyncClient` query methods with timing
- Instrument Cloudinary `upload_image()` and Google OAuth `verify_token()`/`exchange_code_for_tokens()` with timing
- Add `GET /metrics` endpoint (JWT-protected) returning structured JSON with per-endpoint stats, DB query stats, external call stats, and slow request log
- Slow-request thresholds: request >= 1000ms, DB query >= 500ms, external call >= 5000ms

## Files changed by layer
- **Core (new)**: `backend/core/metrics.py` — MetricsCollector singleton
- **Core (modified)**: `backend/core/postgres_database.py` — timing on all 6 query methods
- **Core (modified)**: `backend/core/cloudinary_client.py` — timing on upload_image()
- **Models (new)**: `backend/models/metrics.py` — Pydantic response schemas
- **Routers (new)**: `backend/routers/metrics_router.py` — GET /metrics endpoint
- **App**: `backend/main.py` — TimingMiddleware + metrics_router registration
- **Services**: `backend/services/google_auth_provider.py` — timing on OAuth methods

## Manual test plan
```bash
# 1. Start dev server, hit root endpoint, check log for timing line
curl http://localhost:8000/
# Expected log: INFO - GET / 200 X.Xms

# 2. Hit a DB-backed endpoint (requires auth)
curl -H "Authorization: Bearer <jwt>" http://localhost:8000/user/me
# Expected log: timing for both request and DB query

# 3. Query metrics endpoint
curl -H "Authorization: Bearer <jwt>" http://localhost:8000/metrics
# Expected: {"status": 1, "data": {"endpoints": [...], "db_queries": [...], ...}, "message": "ok"}

# 4. Confirm auth is enforced
curl http://localhost:8000/metrics
# Expected: 401 Unauthorized
```

## Notes
- Metrics import in postgres_database.py and cloudinary_client.py is lazy (inside method body) to avoid circular import issues
- All timing instrumentation is in `finally` blocks so it records even on exceptions
- `MetricsCollector` is a module-level singleton — safe for single-worker uvicorn
- endpoints array in /metrics response is sorted by p95_ms descending (slowest first)